### PR TITLE
Fix remaining magenta gun, dark eyes, and invisible shots

### DIFF
--- a/Assets/Asset Packs/Survival Carbine/Textures/Alt Colors/Materials/Carbine_White.mat
+++ b/Assets/Asset Packs/Survival Carbine/Textures/Alt Colors/Materials/Carbine_White.mat
@@ -1,26 +1,50 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-2195156728281238643
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  version: 10
 --- !u!21 &2100000
 Material:
-  serializedVersion: 6
+  serializedVersion: 8
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Carbine_White
-  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-  m_ShaderKeywords: 
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords:
+  - _NORMALMAP
+  m_InvalidKeywords: []
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
+  stringTagMap:
+    RenderType: Opaque
+  disabledShaderPasses:
+  - MOTIONVECTORS
+  m_LockedProperties:
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 2800000, guid: 0b00b9df07dc4e841beaa06c5f9d082e, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
     - _BumpMap:
-        m_Texture: {fileID: 0}
+        m_Texture: {fileID: 2800000, guid: 21660a73d732908429f8534d93359905, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _DetailAlbedoMap:
@@ -55,23 +79,49 @@ Material:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
     m_Floats:
+    - _AddPrecomputedVelocity: 0
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
     - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
     - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
     - _DetailNormalMapScale: 1
     - _DstBlend: 0
-    - _GlossMapScale: 1
+    - _DstBlendAlpha: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0.5
     - _Glossiness: 0.5
     - _GlossyReflections: 1
     - _Metallic: 0
     - _Mode: 0
     - _OcclusionStrength: 1
-    - _Parallax: 0.02
+    - _Parallax: 0.08
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _Surface: 0
     - _UVSec: 0
+    - _WorkflowMode: 1
     - _ZWrite: 1
     m_Colors:
+    - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.2, g: 0.2, b: 0.2, a: 1}
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1

--- a/Assets/Materials/Eye.mat
+++ b/Assets/Materials/Eye.mat
@@ -24,9 +24,10 @@ Material:
   m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
   m_Parent: {fileID: 0}
   m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
+  m_ValidKeywords:
+  - _EMISSION
   m_InvalidKeywords: []
-  m_LightmapFlags: 4
+  m_LightmapFlags: 2
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
@@ -118,9 +119,9 @@ Material:
     - _WorkflowMode: 1
     - _ZWrite: 1
     m_Colors:
-    - _BaseColor: {r: 0.02, g: 0.02, b: 0.02, a: 1}
-    - _Color: {r: 0.02, g: 0.02, b: 0.02, a: 1}
-    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _BaseColor: {r: 0.6, g: 0.02, b: 0.02, a: 1}
+    - _Color: {r: 0.6, g: 0.02, b: 0.02, a: 1}
+    - _EmissionColor: {r: 6, g: 0.1, b: 0.1, a: 1}
     - _SpecColor: {r: 0.2, g: 0.2, b: 0.2, a: 1}
   m_BuildTextureStacks: []
   m_AllowLocking: 1

--- a/Assets/Scripts/Weapon.cs
+++ b/Assets/Scripts/Weapon.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public abstract class Weapon : MonoBehaviour
@@ -10,23 +8,71 @@ public abstract class Weapon : MonoBehaviour
     [SerializeField] ParticleSystem muzzleFlash;
     [SerializeField] GameObject hitEffect;
 
+    [Header("Tracer")]
+    [SerializeField] Color tracerColor = new Color(1f, 0.85f, 0.3f, 1f);
+    [SerializeField] float tracerWidth = 0.04f;
+    [SerializeField] float tracerDuration = 0.06f;
+    [SerializeField] Transform muzzleOrigin;
+
+    static Material s_tracerMaterial;
+
     protected abstract Vector3 GetPosition();
     protected abstract Vector3 GetForward();
 
     public void Shoot()
     {
-        muzzleFlash.Play();
+        if (muzzleFlash != null) muzzleFlash.Play();
         ProcessRaycast();
     }
 
     void ProcessRaycast()
     {
-        RaycastHit hit;
-        if (Physics.Raycast(GetPosition(), GetForward(), out hit, range))
+        Vector3 origin = GetPosition();
+        Vector3 direction = GetForward();
+        Vector3 endPoint = origin + direction * range;
+
+        if (Physics.Raycast(origin, direction, out RaycastHit hit, range))
         {
+            endPoint = hit.point;
             CreateHitImpact(hit);
             ProcessHitEnemy(hit);
         }
+
+        SpawnTracer(GetTracerStart(origin), endPoint);
+    }
+
+    Vector3 GetTracerStart(Vector3 fallback)
+    {
+        if (muzzleOrigin != null) return muzzleOrigin.position;
+        if (muzzleFlash != null) return muzzleFlash.transform.position;
+        return fallback;
+    }
+
+    void SpawnTracer(Vector3 start, Vector3 end)
+    {
+        GameObject go = new GameObject("Tracer");
+        var lr = go.AddComponent<LineRenderer>();
+        lr.material = GetTracerMaterial();
+        lr.startColor = tracerColor;
+        lr.endColor = tracerColor;
+        lr.startWidth = tracerWidth;
+        lr.endWidth = tracerWidth;
+        lr.positionCount = 2;
+        lr.SetPosition(0, start);
+        lr.SetPosition(1, end);
+        lr.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+        lr.receiveShadows = false;
+        lr.useWorldSpace = true;
+        Destroy(go, tracerDuration);
+    }
+
+    static Material GetTracerMaterial()
+    {
+        if (s_tracerMaterial != null) return s_tracerMaterial;
+        Shader shader = Shader.Find("Universal Render Pipeline/Unlit");
+        if (shader == null) shader = Shader.Find("Sprites/Default");
+        s_tracerMaterial = new Material(shader);
+        return s_tracerMaterial;
     }
 
     void ProcessHitEnemy(RaycastHit hit)
@@ -40,6 +86,7 @@ public abstract class Weapon : MonoBehaviour
 
     void CreateHitImpact(RaycastHit hit)
     {
+        if (hitEffect == null) return;
         GameObject impact = Instantiate(hitEffect, hit.point, Quaternion.LookRotation(hit.normal));
         Destroy(impact, .1f);
     }


### PR DESCRIPTION
## Summary
- Convert `Carbine_White.mat` (the Carbine prefab's main body material) from legacy Standard to URP/Lit. The prior URP cleanup only converted `Carbine.mat`, leaving the body magenta.
- Make `Eye.mat` emissive red (`_EMISSION` on, HDR emission `(6, 0.1, 0.1)`, realtime emissive GI) so the enemy's eyes glow instead of appearing flat black.
- Add a runtime `LineRenderer` tracer to `Weapon.Shoot()` so the player can see where their shots go (and where the enemy is shooting from). Tracer color, width, duration, and an optional `muzzleOrigin` are exposed in the Inspector; shared by both `PlayerWeapon` and `EnemyWeapon`.

## Test plan
- [x] Open `Assets/Scenes/FPS.unity` in Unity 6 LTS and press Play.
- [x] Confirm the carbine's main body is white/textured, not magenta.
- [x] Confirm the enemy's eyes glow red (bloom optional but emission should be obviously bright).
- [x] Fire several shots into open space, into walls, and at the enemy — verify a brief yellow tracer is visible in each case.
- [x] Take a hit from the enemy — verify enemy shots also produce a visible tracer.
