### PR TITLE
Align CLAUDE.md max_steps with config (1M)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### ML-Agents Configuration (`config/URLNPC.yaml`)
 - Trainer: PPO
-- `max_steps`: 500,000
+- `max_steps`: 1,000,000
 - `batch_size`: 1024
 - `learning_rate`: 0.0003
 - `time_horizon`: 64


### PR DESCRIPTION
## Summary
Fixes doc drift flagged in #16. `config/URLNPC.yaml` sets `max_steps: 1000000`, but CLAUDE.md stated `500,000`. This aligns the doc to the actual (effective) config value of **1,000,000**, so thesis-quoted numbers match the real training budget.

## Notes
- README does not quote the training `max_steps` at all (its only step reference is the Inspector-level Agent "Max Step: 5000", a distinct setting), so no README change was needed.
- Verified the other quoted values in CLAUDE.md's ML-Agents Configuration section (`batch_size` 1024, `learning_rate` 0.0003, `time_horizon` 64) still match the yaml.

## Acceptance
- All sources that state `max_steps` now agree: `1,000,000`.

Fixes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)