### PR TITLE
Add new set of tests

### DIFF
--- a/Assets/Scripts/ArenaManager.cs
+++ b/Assets/Scripts/ArenaManager.cs
@@ -26,11 +26,11 @@ public class ArenaManager : MonoBehaviour
     [Tooltip("Name of any pre-existing arena root in the scene to remove before generating. Leave as 'Arena' to clear the static scene arena.")]
     [SerializeField] string existingArenaRootName = "Arena";
     [Tooltip("Force a specific arena (0..4). Leave at -1 to pick randomly at startup.")]
-    [SerializeField] int forcedArenaIndex = -1;
+    [SerializeField] internal int forcedArenaIndex = -1;
     [Tooltip("Run seed for reproducible evaluation: drives arena selection, spawn sampling and wander waypoints (see RunRng). 0 = random seed each run. Overridden by '-runSeed <int>' on the command line.")]
-    [SerializeField] int runSeed = 0;
+    [SerializeField] internal int runSeed = 0;
     [Tooltip("Teleport the player to a random NavMesh point on start (seeded — see RunRng), so rounds don't always open from the same spot. Also keeps the player inside whatever arena was generated.")]
-    [SerializeField] bool repositionPlayerOnStart = true;
+    [SerializeField] internal bool repositionPlayerOnStart = true;
 
     [Header("Perimeter walls")]
     [SerializeField] float wallHeight = 5f;
@@ -76,8 +76,13 @@ public class ArenaManager : MonoBehaviour
         EnsureExists();
     }
 
+    // Test seam: PlayMode tests build their own minimal scenes and must not
+    // have an arena auto-spawned into them by the sceneLoaded hook.
+    internal static bool suppressAutoBootstrap;
+
     static void EnsureExists()
     {
+        if (suppressAutoBootstrap) return;
         if (Current != null) return;
         if (FindAnyObjectByType<ArenaManager>() != null) return;
         new GameObject("ArenaManager (auto)").AddComponent<ArenaManager>();

--- a/Assets/Scripts/AssemblyInfo.cs
+++ b/Assets/Scripts/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+using System.Runtime.CompilerServices;
+
+// The test assemblies drive internal seams (RunRng.ResetForNewRun,
+// ArenaManager.suppressAutoBootstrap, serialized config fields) that the
+// game's public API deliberately does not expose.
+[assembly: InternalsVisibleTo("URLNPC.Tests.EditMode")]
+[assembly: InternalsVisibleTo("URLNPC.Tests.PlayMode")]

--- a/Assets/Scripts/AssemblyInfo.cs.meta
+++ b/Assets/Scripts/AssemblyInfo.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f308505e4a17df746af8580b2caf3793

--- a/Assets/Scripts/Counter.cs
+++ b/Assets/Scripts/Counter.cs
@@ -5,7 +5,7 @@ using TMPro;
 
 public class Counter : MonoBehaviour
 {
-    [SerializeField] TMP_Text counter;
+    [SerializeField] internal TMP_Text counter;
 
     void Update()
     {

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -12,7 +12,7 @@ public class GameManager : MonoBehaviour
 
     [Header("Round clock")]
     [Tooltip("Round length in seconds (game time, so it scales with the trainer's time_scale). Timeout ends the round as a DRAW. Set to 0 or negative to disable the clock.")]
-    [SerializeField] float roundDurationSeconds = 120f;
+    [SerializeField] internal float roundDurationSeconds = 120f;
     [Tooltip("Optional HUD text for the clock. Left empty (the scene is binary serialized), one is created at runtime on the HUD canvas.")]
     [SerializeField] TMP_Text timerText;
 

--- a/Assets/Scripts/RunRng.cs
+++ b/Assets/Scripts/RunRng.cs
@@ -44,9 +44,10 @@ public static class RunRng
     // Statics survive Enter Play Mode with domain reload disabled — reset per
     // play session so a stale seed never leaks into the next run. (Fires once
     // per session, not per SceneManager.LoadScene, so the streams still
-    // persist across round reloads within a run.)
+    // persist across round reloads within a run.) Internal: tests reset the
+    // streams between cases for the same isolation reason.
     [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
-    static void ResetForNewRun()
+    internal static void ResetForNewRun()
     {
         Initialized = false;
         streams = null;

--- a/Assets/Scripts/URLNPC.asmdef
+++ b/Assets/Scripts/URLNPC.asmdef
@@ -1,0 +1,20 @@
+{
+    "name": "URLNPC",
+    "rootNamespace": "",
+    "references": [
+        "Unity.ML-Agents",
+        "Unity.AI.Navigation",
+        "Unity.InputSystem",
+        "Unity.TextMeshPro",
+        "UnityEngine.UI"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Scripts/URLNPC.asmdef.meta
+++ b/Assets/Scripts/URLNPC.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ba18eb0f94eb26c5c94f000c433a3066
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests.meta
+++ b/Assets/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 685c4b26f6fad6b2a8e1a0cecba1b679
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode.meta
+++ b/Assets/Tests/EditMode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 22567335cfea76514981129a67940566
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode/CounterDataTests.cs
+++ b/Assets/Tests/EditMode/CounterDataTests.cs
@@ -1,0 +1,89 @@
+using NUnit.Framework;
+using UnityEngine;
+
+/// <summary>
+/// CounterData persists the win/loss/draw tally in PlayerPrefs. The fixture
+/// snapshots the real on-disk values and restores them afterwards, so running
+/// the suite never clobbers an actual score.
+/// </summary>
+public class CounterDataTests
+{
+    // Must match the private keys in CounterData.cs.
+    const string UserKey = "URLNPC.userPoints";
+    const string NpcKey = "URLNPC.npcPoints";
+    const string DrawsKey = "URLNPC.draws";
+    static readonly string[] Keys = { UserKey, NpcKey, DrawsKey };
+
+    readonly bool[] hadKey = new bool[Keys.Length];
+    readonly int[] savedValue = new int[Keys.Length];
+
+    [SetUp]
+    public void SnapshotRealScores()
+    {
+        for (int i = 0; i < Keys.Length; i++)
+        {
+            hadKey[i] = PlayerPrefs.HasKey(Keys[i]);
+            savedValue[i] = PlayerPrefs.GetInt(Keys[i], 0);
+        }
+        CounterData.ResetScores();
+    }
+
+    [TearDown]
+    public void RestoreRealScores()
+    {
+        for (int i = 0; i < Keys.Length; i++)
+        {
+            if (hadKey[i]) PlayerPrefs.SetInt(Keys[i], savedValue[i]);
+            else PlayerPrefs.DeleteKey(Keys[i]);
+        }
+        PlayerPrefs.Save();
+    }
+
+    [Test]
+    public void FreshTally_ReadsAllZero()
+    {
+        Assert.That(CounterData.readUserPoints(), Is.Zero);
+        Assert.That(CounterData.readNpcPoints(), Is.Zero);
+        Assert.That(CounterData.readDraws(), Is.Zero);
+    }
+
+    [Test]
+    public void UserWins_IncrementsOnlyUserPoints()
+    {
+        CounterData.UserWins();
+        CounterData.UserWins();
+        Assert.That(CounterData.readUserPoints(), Is.EqualTo(2));
+        Assert.That(CounterData.readNpcPoints(), Is.Zero);
+        Assert.That(CounterData.readDraws(), Is.Zero);
+    }
+
+    [Test]
+    public void NpcWins_IncrementsOnlyNpcPoints()
+    {
+        CounterData.NpcWins();
+        Assert.That(CounterData.readNpcPoints(), Is.EqualTo(1));
+        Assert.That(CounterData.readUserPoints(), Is.Zero);
+        Assert.That(CounterData.readDraws(), Is.Zero);
+    }
+
+    [Test]
+    public void Draw_IncrementsOnlyDraws()
+    {
+        CounterData.Draw();
+        Assert.That(CounterData.readDraws(), Is.EqualTo(1));
+        Assert.That(CounterData.readUserPoints(), Is.Zero);
+        Assert.That(CounterData.readNpcPoints(), Is.Zero);
+    }
+
+    [Test]
+    public void ResetScores_ZeroesEverything()
+    {
+        CounterData.UserWins();
+        CounterData.NpcWins();
+        CounterData.Draw();
+        CounterData.ResetScores();
+        Assert.That(CounterData.readUserPoints(), Is.Zero);
+        Assert.That(CounterData.readNpcPoints(), Is.Zero);
+        Assert.That(CounterData.readDraws(), Is.Zero);
+    }
+}

--- a/Assets/Tests/EditMode/CounterDataTests.cs.meta
+++ b/Assets/Tests/EditMode/CounterDataTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bee26ae8d816e96a2bc2ed7068ec123e

--- a/Assets/Tests/EditMode/HealthTests.cs
+++ b/Assets/Tests/EditMode/HealthTests.cs
@@ -1,0 +1,85 @@
+using NUnit.Framework;
+using UnityEngine;
+
+/// <summary>
+/// Health drives the whole reward/win-loss chain (EnemyAgent subscribes to
+/// OnDamaged/OnDied, GameManager decides the round from deaths), so its event
+/// semantics are load-bearing: exact damage payloads, death fires exactly
+/// once, and ResetHealth re-arms it for the next episode.
+/// (EditMode: Start() never runs, so the GameManager lookup stays null and
+/// CheckDeath's null guard keeps death processing local to the component.)
+/// </summary>
+public class HealthTests
+{
+    GameObject go;
+    Health health;
+
+    [SetUp]
+    public void SetUp()
+    {
+        go = new GameObject("HealthTest");
+        health = go.AddComponent<Health>();
+        health.maxHealth = 100f;
+        health.health = 100f;
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Object.DestroyImmediate(go);
+    }
+
+    [Test]
+    public void DecreaseHealth_SubtractsAndFiresOnDamagedWithAmount()
+    {
+        float reported = -1f;
+        health.OnDamaged += amount => reported = amount;
+
+        health.DecreaseHealth(30f);
+
+        Assert.That(health.health, Is.EqualTo(70f));
+        Assert.That(reported, Is.EqualTo(30f));
+    }
+
+    [Test]
+    public void LethalDamage_FiresOnDiedOnce_AndFurtherDamageIsIgnored()
+    {
+        int deaths = 0;
+        int damagedEvents = 0;
+        health.OnDied += () => deaths++;
+        health.OnDamaged += _ => damagedEvents++;
+
+        health.DecreaseHealth(150f);
+        float healthAtDeath = health.health;
+        health.DecreaseHealth(10f);
+
+        Assert.That(deaths, Is.EqualTo(1));
+        Assert.That(damagedEvents, Is.EqualTo(1), "damage while dead must not fire events");
+        Assert.That(health.health, Is.EqualTo(healthAtDeath), "damage while dead must not change health");
+    }
+
+    [Test]
+    public void ExactlyZeroHealth_CountsAsDead()
+    {
+        int deaths = 0;
+        health.OnDied += () => deaths++;
+
+        health.DecreaseHealth(100f);
+
+        Assert.That(deaths, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void ResetHealth_RestoresMaxAndReArmsDeath()
+    {
+        int deaths = 0;
+        health.OnDied += () => deaths++;
+        health.DecreaseHealth(200f);
+
+        health.ResetHealth();
+        Assert.That(health.health, Is.EqualTo(health.maxHealth));
+
+        health.DecreaseHealth(200f);
+        Assert.That(deaths, Is.EqualTo(2), "a reset entity must be able to die again");
+    }
+}

--- a/Assets/Tests/EditMode/HealthTests.cs.meta
+++ b/Assets/Tests/EditMode/HealthTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f757f4c5275e8890d81e7cffd855f721

--- a/Assets/Tests/EditMode/PerceptionMemoryTests.cs
+++ b/Assets/Tests/EditMode/PerceptionMemoryTests.cs
@@ -1,0 +1,55 @@
+using NUnit.Framework;
+using UnityEngine;
+
+/// <summary>
+/// Never-seen invariants of the sensory contract: a fresh (or wiped) memory
+/// must report nothing about the player. The full sighting/freezing behavior
+/// needs real geometry and runs in PlayMode (PerceptionContractTests).
+/// (EditMode: Awake never runs, so the EnemyBehavior lookup stays null and
+/// Refresh must degrade to "not visible" rather than throw.)
+/// </summary>
+public class PerceptionMemoryTests
+{
+    GameObject go;
+    PerceptionMemory memory;
+
+    [SetUp]
+    public void SetUp()
+    {
+        go = new GameObject("PerceptionTest");
+        memory = go.AddComponent<PerceptionMemory>();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Object.DestroyImmediate(go);
+    }
+
+    [Test]
+    public void FreshMemory_HasNeverSeenAnything()
+    {
+        Assert.That(memory.HasEverSeen, Is.False);
+        Assert.That(memory.CurrentlyVisible, Is.False);
+        Assert.That(memory.TimeSinceSeen, Is.EqualTo(Mathf.Infinity));
+        Assert.That(memory.LastSeenPosition, Is.EqualTo(Vector3.zero));
+    }
+
+    [Test]
+    public void Refresh_WithoutBehavior_ReportsNotVisibleInsteadOfThrowing()
+    {
+        memory.Refresh();
+        Assert.That(memory.CurrentlyVisible, Is.False);
+        Assert.That(memory.HasEverSeen, Is.False);
+    }
+
+    [Test]
+    public void Forget_ResetsToNeverSeenState()
+    {
+        memory.Forget();
+        Assert.That(memory.HasEverSeen, Is.False);
+        Assert.That(memory.CurrentlyVisible, Is.False);
+        Assert.That(memory.TimeSinceSeen, Is.EqualTo(Mathf.Infinity));
+        Assert.That(memory.LastSeenPosition, Is.EqualTo(Vector3.zero));
+    }
+}

--- a/Assets/Tests/EditMode/PerceptionMemoryTests.cs.meta
+++ b/Assets/Tests/EditMode/PerceptionMemoryTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 03e3cb5308ee15b7ea7ae5bb5be55635

--- a/Assets/Tests/EditMode/RunRngTests.cs
+++ b/Assets/Tests/EditMode/RunRngTests.cs
@@ -1,0 +1,149 @@
+using NUnit.Framework;
+
+/// <summary>
+/// Guards the reproducibility contract (CLAUDE.md "Reproducibility"): a run
+/// seed fully determines every evaluation-relevant random sequence, and each
+/// domain draws from its own sub-stream so activity in one domain can never
+/// shift the others.
+/// </summary>
+public class RunRngTests
+{
+    [SetUp]
+    public void SetUp()
+    {
+        RunRng.ResetForNewRun();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        // Leave the statics as a fresh play session would find them.
+        RunRng.ResetForNewRun();
+    }
+
+    // The editor process itself can carry -runSeed, which outranks the
+    // inspector seed and would invalidate the tests that rely on two
+    // different effective seeds. The determinism tests are unaffected.
+    static void RequireNoCommandLineSeed()
+    {
+        RunRng.EnsureInitialized(1);
+        bool overridden = RunRng.SeedSource == "command line";
+        RunRng.ResetForNewRun();
+        if (overridden) Assert.Ignore("Editor was launched with -runSeed; inspector-seed tests do not apply.");
+    }
+
+    static int[] DrawInts(RunRng.Stream stream, int count)
+    {
+        var values = new int[count];
+        for (int i = 0; i < count; i++) values[i] = RunRng.Range(stream, 0, int.MaxValue);
+        return values;
+    }
+
+    static float[] DrawFloats(RunRng.Stream stream, int count)
+    {
+        var values = new float[count];
+        for (int i = 0; i < count; i++) values[i] = RunRng.Range(stream, -100f, 100f);
+        return values;
+    }
+
+    [Test]
+    public void SameSeed_ProducesIdenticalSequences_PerStream()
+    {
+        RunRng.EnsureInitialized(42);
+        int[] arena1 = DrawInts(RunRng.Stream.Arena, 20);
+        int[] spawn1 = DrawInts(RunRng.Stream.Spawn, 20);
+        float[] wander1 = DrawFloats(RunRng.Stream.Wander, 20);
+
+        RunRng.ResetForNewRun();
+        RunRng.EnsureInitialized(42);
+        Assert.That(DrawInts(RunRng.Stream.Arena, 20), Is.EqualTo(arena1));
+        Assert.That(DrawInts(RunRng.Stream.Spawn, 20), Is.EqualTo(spawn1));
+        Assert.That(DrawFloats(RunRng.Stream.Wander, 20), Is.EqualTo(wander1));
+    }
+
+    [Test]
+    public void DifferentSeeds_ProduceDifferentSequences()
+    {
+        RequireNoCommandLineSeed();
+
+        RunRng.EnsureInitialized(42);
+        int[] first = DrawInts(RunRng.Stream.Arena, 20);
+
+        RunRng.ResetForNewRun();
+        RunRng.EnsureInitialized(43);
+        Assert.That(DrawInts(RunRng.Stream.Arena, 20), Is.Not.EqualTo(first));
+    }
+
+    [Test]
+    public void Streams_AreIndependent_DrawsInOneDoNotShiftAnother()
+    {
+        RunRng.EnsureInitialized(42);
+        int[] arenaBaseline = DrawInts(RunRng.Stream.Arena, 10);
+        int[] spawnBaseline = DrawInts(RunRng.Stream.Spawn, 10);
+
+        RunRng.ResetForNewRun();
+        RunRng.EnsureInitialized(42);
+        // A policy-dependent number of wander draws happens between the
+        // arena/spawn draws in a real run — it must not affect them.
+        DrawFloats(RunRng.Stream.Wander, 137);
+        Assert.That(DrawInts(RunRng.Stream.Arena, 10), Is.EqualTo(arenaBaseline));
+        DrawFloats(RunRng.Stream.Wander, 61);
+        Assert.That(DrawInts(RunRng.Stream.Spawn, 10), Is.EqualTo(spawnBaseline));
+    }
+
+    [Test]
+    public void EnsureInitialized_IsIdempotent_LaterSeedsAreIgnored()
+    {
+        RunRng.EnsureInitialized(42);
+        int seed = RunRng.Seed;
+        int[] partial = DrawInts(RunRng.Stream.Arena, 5);
+
+        // A scene reload calls EnsureInitialized again (ArenaManager.Awake) —
+        // the streams must keep advancing, not restart.
+        RunRng.EnsureInitialized(99);
+        Assert.That(RunRng.Seed, Is.EqualTo(seed));
+
+        RunRng.ResetForNewRun();
+        RunRng.EnsureInitialized(42);
+        int[] full = DrawInts(RunRng.Stream.Arena, 10);
+        Assert.That(partial, Is.EqualTo(System.Linq.Enumerable.Take(full, 5)));
+    }
+
+    [Test]
+    public void IntRange_RespectsBounds_MaxExclusive()
+    {
+        RunRng.EnsureInitialized(42);
+        for (int i = 0; i < 1000; i++)
+        {
+            int v = RunRng.Range(RunRng.Stream.Spawn, -3, 5);
+            Assert.That(v, Is.InRange(-3, 4));
+        }
+        Assert.That(RunRng.Range(RunRng.Stream.Spawn, 2, 3), Is.EqualTo(2));
+    }
+
+    [Test]
+    public void FloatRange_RespectsBounds()
+    {
+        RunRng.EnsureInitialized(42);
+        for (int i = 0; i < 1000; i++)
+        {
+            float v = RunRng.Range(RunRng.Stream.Wander, -2.5f, 7.25f);
+            Assert.That(v, Is.InRange(-2.5f, 7.25f));
+        }
+    }
+
+    [Test]
+    public void SeedSource_ReportsInspectorForNonZero_RandomForZero()
+    {
+        RequireNoCommandLineSeed();
+
+        RunRng.EnsureInitialized(7);
+        Assert.That(RunRng.SeedSource, Is.EqualTo("inspector"));
+        Assert.That(RunRng.Seed, Is.EqualTo(7));
+
+        RunRng.ResetForNewRun();
+        RunRng.EnsureInitialized(0);
+        Assert.That(RunRng.SeedSource, Is.EqualTo("random"));
+        Assert.That(RunRng.Initialized, Is.True);
+    }
+}

--- a/Assets/Tests/EditMode/RunRngTests.cs.meta
+++ b/Assets/Tests/EditMode/RunRngTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 757acf786cc7d237a90c60d39f1afe44

--- a/Assets/Tests/EditMode/URLNPC.Tests.EditMode.asmdef
+++ b/Assets/Tests/EditMode/URLNPC.Tests.EditMode.asmdef
@@ -1,0 +1,24 @@
+{
+    "name": "URLNPC.Tests.EditMode",
+    "rootNamespace": "",
+    "references": [
+        "URLNPC",
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Tests/EditMode/URLNPC.Tests.EditMode.asmdef.meta
+++ b/Assets/Tests/EditMode/URLNPC.Tests.EditMode.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c207b462f63f89e36b2e595349d6c4c0
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/PlayMode.meta
+++ b/Assets/Tests/PlayMode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 126bbf17af031088e93fb12140c145d7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/PlayMode/ArenaSeedingTests.cs
+++ b/Assets/Tests/PlayMode/ArenaSeedingTests.cs
@@ -1,0 +1,135 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.AI;
+using UnityEngine.TestTools;
+
+/// <summary>
+/// End-to-end reproducibility (issue #13): a run seed fully determines which
+/// arena is built and where actors spawn, spawn points land on the freshly
+/// baked NavMesh at floor level, and the enemy's spawn keeps its distance
+/// from the player.
+/// </summary>
+public class ArenaSeedingTests : PlayModeTestBase
+{
+    ArenaManager CreateManager(int seed, int forcedIndex = -1)
+    {
+        GameObject go = Track(new GameObject("TestArenaManager"));
+        go.SetActive(false);
+        var manager = go.AddComponent<ArenaManager>();
+        manager.runSeed = seed;
+        manager.forcedArenaIndex = forcedIndex;
+        manager.repositionPlayerOnStart = false;
+        go.SetActive(true); // Awake: seeds RunRng, builds the arena, bakes the NavMesh
+        return manager;
+    }
+
+    void DestroyArena(ArenaManager manager)
+    {
+        Object.DestroyImmediate(manager.gameObject);
+        SweepArenas();
+    }
+
+    // A -runSeed on the editor's own command line outranks the inspector
+    // seed, which would collapse "two different seeds" into one.
+    static void RequireInspectorSeedInEffect()
+    {
+        if (RunRng.SeedSource == "command line")
+        {
+            Assert.Ignore("Editor was launched with -runSeed; distinct-seed tests do not apply.");
+        }
+    }
+
+    static Vector3[] DrawGroundPoints(ArenaManager manager, int count)
+    {
+        var points = new Vector3[count];
+        for (int i = 0; i < count; i++) points[i] = manager.RandomGroundPoint();
+        return points;
+    }
+
+    [Test]
+    public void SameSeed_RebuildsSameArena_AndSameSpawnSequence()
+    {
+        ArenaManager m1 = CreateManager(12345);
+        int index1 = m1.ActiveArenaIndex;
+        Vector3[] points1 = DrawGroundPoints(m1, 5);
+
+        DestroyArena(m1);
+        RunRng.ResetForNewRun(); // a fresh run with the same seed
+
+        ArenaManager m2 = CreateManager(12345);
+        Assert.That(m2.ActiveArenaIndex, Is.EqualTo(index1), "same seed must select the same arena");
+        Vector3[] points2 = DrawGroundPoints(m2, 5);
+        for (int i = 0; i < points1.Length; i++)
+        {
+            Assert.That((points2[i] - points1[i]).magnitude, Is.LessThan(1e-3f),
+                $"spawn point #{i} must replay identically for the same seed");
+        }
+    }
+
+    [Test]
+    public void DifferentSeeds_ProduceDifferentSpawns()
+    {
+        ArenaManager m1 = CreateManager(111);
+        RequireInspectorSeedInEffect();
+        Vector3 p1 = m1.RandomGroundPoint();
+
+        DestroyArena(m1);
+        RunRng.ResetForNewRun();
+
+        ArenaManager m2 = CreateManager(222);
+        Vector3 p2 = m2.RandomGroundPoint();
+        Assert.That((p1 - p2).magnitude, Is.GreaterThan(1e-4f));
+    }
+
+    [Test]
+    public void ForcedArenaIndex_OverridesRandomSelection()
+    {
+        ArenaManager manager = CreateManager(1, forcedIndex: 3);
+        Assert.That(manager.ActiveArenaIndex, Is.EqualTo(3));
+        Assert.That(manager.ActiveArenaName, Is.Not.Null.And.Not.Empty);
+    }
+
+    [Test]
+    public void GroundPoints_LandOnTheBakedNavMesh_AtFloorLevel()
+    {
+        ArenaManager manager = CreateManager(42);
+        for (int i = 0; i < 20; i++)
+        {
+            Vector3 point = manager.RandomGroundPoint();
+            Assert.That(NavMesh.SamplePosition(point, out NavMeshHit hit, 0.5f, NavMesh.AllAreas), Is.True,
+                $"point #{i} {point} is not on the NavMesh");
+            Assert.That((hit.position - point).magnitude, Is.LessThan(0.11f));
+            Assert.That(point.y, Is.LessThanOrEqualTo(0.65f), "spawns must stay on the open floor, not on cover");
+        }
+    }
+
+    [UnityTest]
+    public IEnumerator EnemySpawn_LandsOnNavMesh_AwayFromThePlayer()
+    {
+        ArenaManager manager = CreateManager(777, forcedIndex: 0); // Courtyard: the big open floor
+
+        GameObject player = Track(GameObject.CreatePrimitive(PrimitiveType.Capsule));
+        player.name = "TestPlayer";
+        player.tag = "Player";
+        player.transform.position = new Vector3(-15f, 1f, -15f);
+        Physics.SyncTransforms();
+
+        GameObject enemyGo = Track(new GameObject("TestEnemy"));
+        enemyGo.SetActive(false);
+        enemyGo.AddComponent<NavMeshAgent>();
+        var behavior = enemyGo.AddComponent<EnemyBehavior>();
+        behavior.target = player.transform;
+        enemyGo.SetActive(true);
+        yield return null; // Start → InitAtRandomPosition on the baked NavMesh
+
+        Vector3 spawn = enemyGo.transform.position;
+        Assert.That(NavMesh.SamplePosition(spawn, out NavMeshHit _, 1.5f, NavMesh.AllAreas), Is.True,
+            $"enemy spawned off the NavMesh at {spawn}");
+
+        float minSeparation = Mathf.Min(25f, manager.SpawnSeparationCap); // 25 is EnemyBehavior's default
+        float distance = Vector3.Distance(spawn, player.transform.position);
+        Assert.That(distance, Is.GreaterThanOrEqualTo(minSeparation - 1.5f),
+            "enemy must not spawn on top of the player");
+    }
+}

--- a/Assets/Tests/PlayMode/ArenaSeedingTests.cs.meta
+++ b/Assets/Tests/PlayMode/ArenaSeedingTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 137e2b1dd1b95b056911bfd919a82904

--- a/Assets/Tests/PlayMode/EnemyAgentTests.cs
+++ b/Assets/Tests/PlayMode/EnemyAgentTests.cs
@@ -1,0 +1,126 @@
+using System.Collections;
+using NUnit.Framework;
+using Unity.MLAgents;
+using Unity.MLAgents.Policies;
+using UnityEngine;
+using UnityEngine.AI;
+using UnityEngine.TestTools;
+
+/// <summary>
+/// The reward/episode plumbing of EnemyAgent against a live Academy (no
+/// trainer connected — same as pressing Play): health events map to the
+/// documented reward shape, and both terminal paths (timeout, target death)
+/// end the episode and reset state. Also a wiring smoke test for the actual
+/// Enemy prefab, whose BehaviorParameters/DecisionRequester are required for
+/// ML-Agents to drive it at all (see CLAUDE.md).
+/// </summary>
+public class EnemyAgentTests : PlayModeTestBase
+{
+    GameObject player;
+    Health playerHealth;
+    EnemyAgent agent;
+    Health selfHealth;
+
+    IEnumerator BuildAgentScene()
+    {
+        player = Track(GameObject.CreatePrimitive(PrimitiveType.Capsule));
+        player.name = "TestPlayer";
+        player.tag = "Player";
+        player.transform.position = new Vector3(0f, 0f, 10f);
+        playerHealth = player.AddComponent<Health>();
+
+        GameObject enemyGo = Track(new GameObject("TestEnemyAgent"));
+        enemyGo.SetActive(false);
+        enemyGo.AddComponent<NavMeshAgent>().enabled = false;
+        agent = enemyGo.AddComponent<EnemyAgent>(); // RequireComponent pulls in EnemyBehavior + Health (+ BehaviorParameters)
+        var behavior = enemyGo.GetComponent<EnemyBehavior>();
+        behavior.enabled = false; // no NavMesh in this fixture: skip Start's spawn
+        behavior.target = player.transform;
+        selfHealth = enemyGo.GetComponent<Health>();
+        enemyGo.SetActive(true); // Agent.OnEnable → Academy init → Initialize()
+        yield return null;       // EnemyAgent.Update subscribes to the target's Health
+    }
+
+    [UnityTest]
+    public IEnumerator HealthEvents_MapToTheDocumentedRewardShape()
+    {
+        yield return BuildAgentScene();
+
+        // No DecisionRequester here, so no per-step rewards muddy the water:
+        // the cumulative reward moves only on health events.
+        float baseline = agent.GetCumulativeReward();
+
+        playerHealth.DecreaseHealth(10f);
+        Assert.That(agent.GetCumulativeReward() - baseline, Is.EqualTo(0.5f).Within(1e-4f),
+            "hitting the target must pay hitTargetReward (+0.5)");
+
+        selfHealth.DecreaseHealth(10f);
+        Assert.That(agent.GetCumulativeReward() - baseline, Is.EqualTo(0f).Within(1e-4f),
+            "getting hit must cost gotHitPenalty (-0.5)");
+    }
+
+    [UnityTest]
+    public IEnumerator RoundTimeout_EndsTheEpisode()
+    {
+        yield return BuildAgentScene();
+        // The episode reset respawns the enemy; without a NavMesh that logs
+        // placement complaints, which are expected in this fixture.
+        LogAssert.ignoreFailingMessages = true;
+
+        int episodes = agent.CompletedEpisodes;
+        agent.OnRoundTimeout();
+        Assert.That(agent.CompletedEpisodes, Is.EqualTo(episodes + 1));
+    }
+
+    [UnityTest]
+    public IEnumerator TargetDeath_EndsTheEpisode_AndResetsBothHealths()
+    {
+        yield return BuildAgentScene();
+        LogAssert.ignoreFailingMessages = true;
+
+        selfHealth.DecreaseHealth(30f); // dent the enemy so the reset is observable
+        int episodes = agent.CompletedEpisodes;
+
+        playerHealth.DecreaseHealth(playerHealth.maxHealth + 1f);
+
+        Assert.That(agent.CompletedEpisodes, Is.EqualTo(episodes + 1), "killing the target must end the episode");
+        Assert.That(playerHealth.health, Is.EqualTo(playerHealth.maxHealth), "OnEpisodeBegin must reset the target's health");
+        Assert.That(selfHealth.health, Is.EqualTo(selfHealth.maxHealth), "OnEpisodeBegin must reset the enemy's health");
+    }
+
+#if UNITY_EDITOR
+    [UnityTest]
+    public IEnumerator EnemyPrefab_CarriesMlAgentsWiring_AndTheClockOwnsTimeout()
+    {
+        // The prefab spawns without a NavMesh here and may carry a stale
+        // serialized MaxStep (which Initialize overrides with a warning).
+        LogAssert.ignoreFailingMessages = true;
+
+        var prefab = UnityEditor.AssetDatabase.LoadAssetAtPath<GameObject>("Assets/Prefabs/Characters/Enemy.prefab");
+        Assert.That(prefab, Is.Not.Null, "Enemy prefab not found at the path CLAUDE.md documents");
+
+        player = Track(GameObject.CreatePrimitive(PrimitiveType.Capsule));
+        player.tag = "Player";
+        player.transform.position = new Vector3(0f, 0f, 30f); // out of sight range: the enemy just patrols
+        player.AddComponent<Health>();
+
+        GameObject enemy = Track(Object.Instantiate(prefab, new Vector3(0f, 0f, -30f), Quaternion.identity));
+        yield return null;
+        yield return null;
+
+        var prefabAgent = enemy.GetComponent<EnemyAgent>();
+        Assert.That(prefabAgent, Is.Not.Null);
+        Assert.That(prefabAgent.MaxStep, Is.Zero,
+            "the round clock is the single owner of time-based episode termination");
+
+        var behaviorParams = enemy.GetComponent<BehaviorParameters>();
+        Assert.That(behaviorParams, Is.Not.Null, "no BehaviorParameters — ML-Agents cannot drive the enemy");
+        Assert.That(behaviorParams.BehaviorName, Is.EqualTo("URLNPC"));
+        Assert.That(behaviorParams.BrainParameters.VectorObservationSize, Is.EqualTo(3));
+        Assert.That(behaviorParams.BrainParameters.ActionSpec.BranchSizes, Is.EqualTo(new[] { 3 }));
+
+        Assert.That(enemy.GetComponent<DecisionRequester>(), Is.Not.Null,
+            "no DecisionRequester — the enemy would stand still in every mode");
+    }
+#endif
+}

--- a/Assets/Tests/PlayMode/EnemyAgentTests.cs.meta
+++ b/Assets/Tests/PlayMode/EnemyAgentTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dd66f5608787ecaf695b8ffbaf66aeb6

--- a/Assets/Tests/PlayMode/GameManagerDeathTests.cs
+++ b/Assets/Tests/PlayMode/GameManagerDeathTests.cs
@@ -1,0 +1,46 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+/// <summary>
+/// Win/loss accounting: GameManager.ProcessDeath maps the loser's tag to the
+/// opposite side's score and ends the round (human-play path — the tests run
+/// with no trainer connected, exactly like a player pressing Play).
+/// </summary>
+public class GameManagerDeathTests : PlayModeTestBase
+{
+    [UnityTest]
+    public IEnumerator NpcDeath_CountsUserWin_AndFinishesRound()
+    {
+        CreateCounterHud();
+        GameManager gm = CreateGameManager(60f);
+        yield return null; // Start wires the counter
+
+        int userBefore = CounterData.readUserPoints();
+        int npcBefore = CounterData.readNpcPoints();
+
+        gm.ProcessDeath("NPC");
+
+        Assert.That(CounterData.readUserPoints(), Is.EqualTo(userBefore + 1));
+        Assert.That(CounterData.readNpcPoints(), Is.EqualTo(npcBefore));
+        Assert.That(Time.timeScale, Is.Zero, "a decided round must freeze the scene");
+    }
+
+    [UnityTest]
+    public IEnumerator PlayerDeath_CountsNpcWin_AndFinishesRound()
+    {
+        CreateCounterHud();
+        GameManager gm = CreateGameManager(60f);
+        yield return null;
+
+        int userBefore = CounterData.readUserPoints();
+        int npcBefore = CounterData.readNpcPoints();
+
+        gm.ProcessDeath("Player");
+
+        Assert.That(CounterData.readNpcPoints(), Is.EqualTo(npcBefore + 1));
+        Assert.That(CounterData.readUserPoints(), Is.EqualTo(userBefore));
+        Assert.That(Time.timeScale, Is.Zero);
+    }
+}

--- a/Assets/Tests/PlayMode/GameManagerDeathTests.cs.meta
+++ b/Assets/Tests/PlayMode/GameManagerDeathTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4dc8e769bdb2aff17b974d5614e113d5

--- a/Assets/Tests/PlayMode/PerceptionContractTests.cs
+++ b/Assets/Tests/PlayMode/PerceptionContractTests.cs
@@ -1,0 +1,133 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.AI;
+using UnityEngine.TestTools;
+
+/// <summary>
+/// The sensory contract (issue #9) against real geometry: the NPC knows the
+/// player's position only while line of sight holds; the moment sight breaks
+/// the memory freezes at the last-seen point, and episode resets wipe it.
+///
+/// The enemy is assembled with its NavMeshAgent and EnemyBehavior disabled —
+/// there is no NavMesh in this fixture and the sight check needs neither
+/// Start() spawning nor navigation, only transforms and raycasts.
+/// </summary>
+public class PerceptionContractTests : PlayModeTestBase
+{
+    GameObject player;
+    GameObject enemyGo;
+    EnemyBehavior behavior;
+    PerceptionMemory memory;
+
+    IEnumerator BuildScene()
+    {
+        // Spawn out of sight (behind AND beyond sightRange): PerceptionMemory
+        // auto-refreshes every frame, so a player spawned in view would be
+        // memorized before the test repositions it.
+        player = Track(GameObject.CreatePrimitive(PrimitiveType.Capsule));
+        player.name = "TestPlayer";
+        player.tag = "Player";
+        player.transform.position = new Vector3(0f, 0f, -30f);
+
+        enemyGo = Track(new GameObject("TestEnemy"));
+        enemyGo.SetActive(false);
+        enemyGo.AddComponent<NavMeshAgent>().enabled = false;
+        behavior = enemyGo.AddComponent<EnemyBehavior>();
+        behavior.enabled = false; // skip Start(): no NavMesh to spawn on
+        behavior.target = player.transform;
+        enemyGo.transform.SetPositionAndRotation(Vector3.zero, Quaternion.identity); // facing +Z, toward the player
+        enemyGo.SetActive(true); // Awake auto-adds PerceptionMemory
+        memory = behavior.Perception;
+        Assert.That(memory, Is.Not.Null, "EnemyBehavior.Awake must auto-add PerceptionMemory");
+
+        yield return new WaitForFixedUpdate(); // let physics register the colliders
+    }
+
+    static void MoveAndSync(Transform t, Vector3 position)
+    {
+        t.position = position;
+        Physics.SyncTransforms();
+    }
+
+    [UnityTest]
+    public IEnumerator Memory_TracksWhileVisible_FreezesWhenSightBreaks()
+    {
+        yield return BuildScene();
+
+        MoveAndSync(player.transform, new Vector3(0f, 0f, 10f)); // step into view
+        memory.Refresh();
+        Assert.That(memory.CurrentlyVisible, Is.True, "clear line of sight in range and FOV");
+        Assert.That(memory.HasEverSeen, Is.True);
+        Assert.That(memory.LastSeenPosition, Is.EqualTo(player.transform.position));
+
+        // While visible the memory tracks the live position.
+        MoveAndSync(player.transform, new Vector3(2f, 0f, 10f));
+        memory.Refresh();
+        Assert.That(memory.CurrentlyVisible, Is.True);
+        Assert.That(memory.LastSeenPosition, Is.EqualTo(player.transform.position));
+        Vector3 lastSeen = memory.LastSeenPosition;
+
+        // A wall between them breaks sight; the memory must freeze, not track.
+        GameObject wall = Track(GameObject.CreatePrimitive(PrimitiveType.Cube));
+        wall.transform.localScale = new Vector3(8f, 4f, 1f);
+        MoveAndSync(wall.transform, new Vector3(1f, 0f, 5f));
+        memory.Refresh();
+        Assert.That(memory.CurrentlyVisible, Is.False, "a wall must break line of sight");
+        Assert.That(memory.HasEverSeen, Is.True, "memory outlives sight");
+        Assert.That(memory.LastSeenPosition, Is.EqualTo(lastSeen), "position must freeze at the last sighting");
+
+        // The player moving behind the wall must not leak into the memory.
+        MoveAndSync(player.transform, new Vector3(-4f, 0f, 12f));
+        memory.Refresh();
+        Assert.That(memory.CurrentlyVisible, Is.False);
+        Assert.That(memory.LastSeenPosition, Is.EqualTo(lastSeen), "the NPC must not wallhack-track the player");
+
+        // Time since the sighting keeps growing while blind.
+        float before = memory.TimeSinceSeen;
+        yield return new WaitForSeconds(0.05f);
+        Assert.That(memory.TimeSinceSeen, Is.GreaterThan(before));
+    }
+
+    [UnityTest]
+    public IEnumerator TargetOutsideFov_IsNotVisible()
+    {
+        yield return BuildScene();
+
+        MoveAndSync(player.transform, new Vector3(0f, 0f, -10f)); // dead behind (FOV is 120°)
+        memory.Refresh();
+        Assert.That(memory.CurrentlyVisible, Is.False);
+        Assert.That(memory.HasEverSeen, Is.False, "an unseen player must leave no trace");
+    }
+
+    [UnityTest]
+    public IEnumerator TargetBeyondSightRange_IsNotVisible()
+    {
+        yield return BuildScene();
+
+        MoveAndSync(player.transform, new Vector3(0f, 0f, 50f)); // sightRange is 20
+        memory.Refresh();
+        Assert.That(memory.CurrentlyVisible, Is.False);
+        Assert.That(memory.HasEverSeen, Is.False);
+    }
+
+    [UnityTest]
+    public IEnumerator ResetState_WipesMemoryAndShotFlag()
+    {
+        yield return BuildScene();
+
+        MoveAndSync(player.transform, new Vector3(0f, 0f, 10f)); // step into view
+        memory.Refresh();
+        Assert.That(memory.HasEverSeen, Is.True);
+
+        // No NavMesh in this fixture: the respawn inside ResetState logs its
+        // "could not place on NavMesh" complaints, which is expected here.
+        LogAssert.ignoreFailingMessages = true;
+        behavior.ResetState();
+
+        Assert.That(memory.HasEverSeen, Is.False, "last episode's sighting must not leak into the next");
+        Assert.That(memory.CurrentlyVisible, Is.False);
+        Assert.That(memory.LastSeenPosition, Is.EqualTo(Vector3.zero));
+        Assert.That(behavior.DidShoot, Is.False);
+    }
+}

--- a/Assets/Tests/PlayMode/PerceptionContractTests.cs.meta
+++ b/Assets/Tests/PlayMode/PerceptionContractTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f112b4f3ed17121fc87bef7342468e2e

--- a/Assets/Tests/PlayMode/PlayModeTestBase.cs
+++ b/Assets/Tests/PlayMode/PlayModeTestBase.cs
@@ -1,0 +1,123 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using TMPro;
+using UnityEngine;
+using UnityEngine.AI;
+
+/// <summary>
+/// Shared scaffolding for PlayMode integration tests. Guarantees per test:
+/// - No auto-spawned arena: ArenaManager's bootstrap fires on every scene
+///   load (including the test runner's init scene), so the seam suppresses it
+///   and any manager/arena that already snuck in is swept.
+/// - The real score tally survives: PlayerPrefs values are snapshotted in
+///   SetUp and restored in TearDown.
+/// - Engine state is restored: Time.timeScale (GameManager.FinishRound sets
+///   it to 0), cursor state, NavMesh data, and RunRng's static streams.
+/// Spawned objects registered via Track() are destroyed on teardown.
+/// </summary>
+public abstract class PlayModeTestBase
+{
+    // Must match the private keys in CounterData.cs.
+    static readonly string[] PrefKeys = { "URLNPC.userPoints", "URLNPC.npcPoints", "URLNPC.draws" };
+    readonly bool[] hadKey = new bool[PrefKeys.Length];
+    readonly int[] savedValue = new int[PrefKeys.Length];
+
+    readonly List<GameObject> tracked = new List<GameObject>();
+
+    [SetUp]
+    public void BaseSetUp()
+    {
+        ArenaManager.suppressAutoBootstrap = true;
+        SweepArenas();
+
+        for (int i = 0; i < PrefKeys.Length; i++)
+        {
+            hadKey[i] = PlayerPrefs.HasKey(PrefKeys[i]);
+            savedValue[i] = PlayerPrefs.GetInt(PrefKeys[i], 0);
+        }
+
+        Time.timeScale = 1f;
+        RunRng.ResetForNewRun();
+    }
+
+    [TearDown]
+    public void BaseTearDown()
+    {
+        foreach (GameObject go in tracked)
+        {
+            if (go != null) Object.DestroyImmediate(go);
+        }
+        tracked.Clear();
+        SweepArenas();
+
+        for (int i = 0; i < PrefKeys.Length; i++)
+        {
+            if (hadKey[i]) PlayerPrefs.SetInt(PrefKeys[i], savedValue[i]);
+            else PlayerPrefs.DeleteKey(PrefKeys[i]);
+        }
+        PlayerPrefs.Save();
+
+        Time.timeScale = 1f;
+        Cursor.lockState = CursorLockMode.None;
+        Cursor.visible = true;
+        RunRng.ResetForNewRun();
+        ArenaManager.suppressAutoBootstrap = false;
+    }
+
+    /// <summary>Register a spawned object for teardown destruction.</summary>
+    protected GameObject Track(GameObject go)
+    {
+        tracked.Add(go);
+        return go;
+    }
+
+    /// <summary>
+    /// A minimal HUD: Canvas + TMP label wired into a Counter, enough for
+    /// GameManager.Start to find a Counter and hang its runtime timer text on
+    /// the same canvas.
+    /// </summary>
+    protected Counter CreateCounterHud()
+    {
+        GameObject canvasGo = Track(new GameObject("TestHud", typeof(Canvas)));
+        var labelGo = new GameObject("Score");
+        labelGo.transform.SetParent(canvasGo.transform, false);
+        TMP_Text label = labelGo.AddComponent<TextMeshProUGUI>();
+        var counter = canvasGo.AddComponent<Counter>();
+        counter.counter = label;
+        return counter;
+    }
+
+    /// <summary>
+    /// GameManager on a bare GameObject. Created inactive so the round
+    /// duration is in place before Start arms the clock; the caller must
+    /// yield a frame for Start to run.
+    /// </summary>
+    protected GameManager CreateGameManager(float roundDuration)
+    {
+        GameObject go = Track(new GameObject("TestGameManager"));
+        go.SetActive(false);
+        var gm = go.AddComponent<GameManager>();
+        gm.roundDurationSeconds = roundDuration;
+        go.SetActive(true);
+        return gm;
+    }
+
+    /// <summary>
+    /// Remove any ArenaManager (auto-bootstrapped before the first SetUp
+    /// could suppress it, or left over from a test) plus its generated
+    /// geometry and NavMesh.
+    /// </summary>
+    protected static void SweepArenas()
+    {
+        foreach (ArenaManager manager in Object.FindObjectsByType<ArenaManager>(FindObjectsInactive.Include, FindObjectsSortMode.None))
+        {
+            Object.DestroyImmediate(manager.gameObject);
+        }
+        GameObject arena;
+        while ((arena = GameObject.Find("Arena (Generated)")) != null)
+        {
+            Object.DestroyImmediate(arena);
+        }
+        NavMesh.RemoveAllNavMeshData();
+    }
+}

--- a/Assets/Tests/PlayMode/PlayModeTestBase.cs.meta
+++ b/Assets/Tests/PlayMode/PlayModeTestBase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fb2edc4897cd89e71b6481cb21cd07d1

--- a/Assets/Tests/PlayMode/RoundTimerTests.cs
+++ b/Assets/Tests/PlayMode/RoundTimerTests.cs
@@ -1,0 +1,80 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+/// <summary>
+/// The round clock in GameManager: countdown, re-arming, the draw-on-timeout
+/// path (human play — no communicator in tests), and the "clock disabled"
+/// configuration. Uses sub-second rounds so the suite stays fast.
+/// </summary>
+public class RoundTimerTests : PlayModeTestBase
+{
+    [UnityTest]
+    public IEnumerator Clock_CountsDownWhileRoundRuns()
+    {
+        GameManager gm = CreateGameManager(5f);
+        yield return null; // Start arms the clock
+
+        float initial = gm.RemainingRoundTime;
+        Assert.That(initial, Is.GreaterThan(4f).And.LessThanOrEqualTo(5f));
+
+        yield return null;
+        yield return null;
+        Assert.That(gm.RemainingRoundTime, Is.LessThan(initial));
+    }
+
+    [UnityTest]
+    public IEnumerator ResetRoundClock_RearmsFullDuration()
+    {
+        GameManager gm = CreateGameManager(5f);
+        yield return null;
+        yield return new WaitForSeconds(0.1f);
+        Assert.That(gm.RemainingRoundTime, Is.LessThan(5f));
+
+        gm.ResetRoundClock();
+        Assert.That(gm.RemainingRoundTime, Is.EqualTo(5f));
+    }
+
+    [UnityTest]
+    public IEnumerator Timeout_RecordsSingleDraw_AndFreezesRound()
+    {
+        CreateCounterHud();
+        GameManager gm = CreateGameManager(0.3f);
+        int drawsBefore = CounterData.readDraws();
+        int userBefore = CounterData.readUserPoints();
+        int npcBefore = CounterData.readNpcPoints();
+
+        // FinishRound zeroes timeScale, so wait on unscaled time.
+        float safety = 5f;
+        while (Time.timeScale > 0f && safety > 0f)
+        {
+            safety -= Time.unscaledDeltaTime;
+            yield return null;
+        }
+
+        Assert.That(Time.timeScale, Is.Zero, "timeout must freeze the scene in human play");
+        Assert.That(gm.RemainingRoundTime, Is.Zero);
+        Assert.That(CounterData.readDraws(), Is.EqualTo(drawsBefore + 1));
+        Assert.That(CounterData.readUserPoints(), Is.EqualTo(userBefore), "a draw must not hand anyone the win");
+        Assert.That(CounterData.readNpcPoints(), Is.EqualTo(npcBefore));
+
+        // The finished round must not keep counting draws.
+        for (int i = 0; i < 5; i++) yield return null;
+        Assert.That(CounterData.readDraws(), Is.EqualTo(drawsBefore + 1));
+    }
+
+    [UnityTest]
+    public IEnumerator NonPositiveDuration_DisablesTheClock()
+    {
+        CreateCounterHud();
+        GameManager gm = CreateGameManager(0f);
+        int drawsBefore = CounterData.readDraws();
+
+        yield return new WaitForSeconds(0.2f);
+
+        Assert.That(Time.timeScale, Is.EqualTo(1f), "no clock, no timeout, no freeze");
+        Assert.That(gm.RemainingRoundTime, Is.Zero);
+        Assert.That(CounterData.readDraws(), Is.EqualTo(drawsBefore));
+    }
+}

--- a/Assets/Tests/PlayMode/RoundTimerTests.cs.meta
+++ b/Assets/Tests/PlayMode/RoundTimerTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 91d1346fcbc608e439481d0371e5adba

--- a/Assets/Tests/PlayMode/URLNPC.Tests.PlayMode.asmdef
+++ b/Assets/Tests/PlayMode/URLNPC.Tests.PlayMode.asmdef
@@ -1,0 +1,25 @@
+{
+    "name": "URLNPC.Tests.PlayMode",
+    "rootNamespace": "",
+    "references": [
+        "URLNPC",
+        "Unity.ML-Agents",
+        "Unity.AI.Navigation",
+        "Unity.TextMeshPro",
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Tests/PlayMode/URLNPC.Tests.PlayMode.asmdef.meta
+++ b/Assets/Tests/PlayMode/URLNPC.Tests.PlayMode.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0a53f95432457380aaab874b4106b2dc
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,16 @@ The Enemy GameObject **must** carry `BehaviorParameters` + `DecisionRequester` f
 - `wastedShotPenalty` `-0.05` (attack action while target not in sight)
 - `timeoutPenalty` `-0.2` (round clock ran out — draw, ends episode)
 
+## Tests
+
+Unity Test Framework suite in `Assets/Tests/` (EditMode = pure logic, PlayMode = integration with real geometry/NavMesh/Academy). Run headless with `scripts/run-tests.sh [editmode|playmode|all]` (editor must be closed — single instance per project; results in `results/tests/`), or in-editor via the Test Runner window. **Never pass `-runSeed` to the test process** — it outranks the inspector seeds the reproducibility tests set on purpose (the tests `Assert.Ignore` where that would invalidate them).
+
+Structure that must be preserved:
+- `Assets/Scripts/URLNPC.asmdef` — the game scripts' assembly. Test asmdefs can't reference the default `Assembly-CSharp`, so game code must stay in this assembly (StarterAssets etc. remain in `Assembly-CSharp`, which auto-references it). New script dependencies on other packages need their asmdef name added to its `references`.
+- `Assets/Scripts/AssemblyInfo.cs` — `InternalsVisibleTo` for the two test assemblies. Test seams are `internal`: `RunRng.ResetForNewRun()` (stream isolation between tests), `ArenaManager.suppressAutoBootstrap` (keeps the sceneLoaded hook from spawning arenas into test scenes), and a few serialized config fields (`roundDurationSeconds`, `runSeed`, `forcedArenaIndex`, `repositionPlayerOnStart`, `Counter.counter`).
+- `PlayModeTestBase` (in `Assets/Tests/PlayMode/`) — every PlayMode fixture derives from it; it sweeps auto-spawned arenas, snapshots/restores the real PlayerPrefs tally, and resets `Time.timeScale`/NavMesh/RunRng per test.
+- `CounterDataTests`/`PlayModeTestBase` duplicate the private PlayerPrefs key strings from `CounterData.cs` — renaming those keys must update both.
+
 ## Known follow-ups
 
 - **NavMesh bake** — now handled at runtime: `ArenaManager` bakes a `NavMeshSurface` over the generated arena on `Awake`, so no hand-baked NavMesh is required. (A hand-baked NavMesh in the scene is removed at startup.)

--- a/README.md
+++ b/README.md
@@ -126,6 +126,23 @@ Defined in `EnemyAgent.cs` (tunable in Inspector):
 | Died | `-1.0` (ends episode) |
 | Shot while target out of sight | `-0.05` |
 
+## Testing
+
+The project carries a Unity Test Framework suite covering the load-bearing behaviors: seeded reproducibility (`RunRng`, arena/spawn replays), the round clock and draw path, win/loss/draw counters, health/death events, episode resets, and the NPC's sensory contract (`PerceptionMemory`).
+
+- **In the editor:** *Window ▸ General ▸ Test Runner*, then run the `URLNPC.Tests.EditMode` / `URLNPC.Tests.PlayMode` assemblies.
+- **Headless (CLI):** close the editor (Unity is single-instance per project) and run:
+
+  ```bash
+  scripts/run-tests.sh            # EditMode only (fast)
+  scripts/run-tests.sh playmode   # PlayMode integration tests
+  scripts/run-tests.sh all        # both
+  ```
+
+  Results (NUnit XML + log) are written to `results/tests/`. The script auto-detects the editor version pinned in `ProjectSettings/ProjectVersion.txt` under `~/Unity/Hub/Editor/`; override with `UNITY_BIN=/path/to/Unity`.
+
+Test scaffolding restores real state on teardown: your persisted score tally (PlayerPrefs) is snapshotted and put back, and `Time.timeScale`/NavMesh/RNG state are reset per test.
+
 ## Tech stack
 
 - Unity 6 LTS, ML-Agents Release 22 (`com.unity.ml-agents` 3.0.0 — embedded under `Packages/` and locally patched for the renamed Inference Engine package).

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Headless Unity Test Framework runner for URLNPC.
+#
+#   scripts/run-tests.sh [editmode|playmode|all]     (default: editmode)
+#
+# Uses the editor version pinned in ProjectSettings/ProjectVersion.txt from
+# the Unity Hub install location; override with UNITY_BIN=/path/to/Unity.
+# Results (NUnit XML + editor log) land in results/tests/ (gitignored).
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+UNITY_VERSION="$(sed -n 's/^m_EditorVersion: //p' "$PROJECT_ROOT/ProjectSettings/ProjectVersion.txt" | tr -d '\r')"
+UNITY_BIN="${UNITY_BIN:-$HOME/Unity/Hub/Editor/$UNITY_VERSION/Editor/Unity}"
+
+if [[ ! -x "$UNITY_BIN" ]]; then
+    echo "error: Unity $UNITY_VERSION not found at $UNITY_BIN (override with UNITY_BIN=...)" >&2
+    exit 1
+fi
+
+# Unity allows a single instance per project — a batch run against an open
+# project fails with an opaque error, so catch it early.
+if [[ -f "$PROJECT_ROOT/Temp/UnityLockfile" ]]; then
+    echo "error: the project looks open in the Unity editor (Temp/UnityLockfile exists)." >&2
+    echo "Close the editor and retry." >&2
+    exit 1
+fi
+
+RESULTS_DIR="$PROJECT_ROOT/results/tests"
+mkdir -p "$RESULTS_DIR"
+
+run_platform() {
+    local platform="$1" # EditMode | PlayMode
+    local assembly="URLNPC.Tests.$platform"
+    local out="$RESULTS_DIR/$(echo "$platform" | tr '[:upper:]' '[:lower:]')"
+    echo "==> $platform tests ($assembly)..."
+    # -assemblyNames keeps the embedded ML-Agents package tests out of the run.
+    # Never pass -runSeed here: it outranks the inspector seeds that the
+    # reproducibility tests set up on purpose.
+    if "$UNITY_BIN" -batchmode -projectPath "$PROJECT_ROOT" \
+        -runTests -testPlatform "$platform" \
+        -assemblyNames "$assembly" \
+        -testResults "$out.xml" \
+        -logFile "$out.log"; then
+        echo "    PASSED — results: $out.xml"
+    else
+        echo "    FAILED — see $out.xml and $out.log" >&2
+        return 1
+    fi
+}
+
+case "${1:-editmode}" in
+    editmode) run_platform EditMode ;;
+    playmode) run_platform PlayMode ;;
+    all)      run_platform EditMode && run_platform PlayMode ;;
+    *)        echo "usage: $0 [editmode|playmode|all]" >&2; exit 2 ;;
+esac


### PR DESCRIPTION
Add test cases for the new logic in the game to verify regression during further development.

What was built

**Assets/Tests/EditMode/** — fast pure-logic tests: RunRngTests.cs (same seed ⇒ identical sequences, stream independence, idempotent init, range bounds, seed-source reporting), CounterDataTests.cs, HealthTests.cs (event payloads, death fires once, reset re-arms), PerceptionMemoryTests.cs.

**Assets/Tests/PlayMode/** — integration tests: round clock countdown/re-arm/draw-on-timeout/disabled-clock, win-loss accounting via ProcessDeath, the sensory contract against real geometry (memory freezes when a wall breaks sight, no wallhack-tracking, resets wipe it), seeded arena replays (same seed ⇒ same arena + same spawn sequence after a full rebuild), enemy spawn separation on a baked NavMesh, ML-Agents reward events (+0.5 hit / −0.5 got hit), episode termination on timeout and kill, and a wiring smoke test of the actual Enemy prefab (MaxStep forced to 0, BehaviorParameters/DecisionRequester present, obs size 3). PlayModeTestBase.cs snapshots/restores your real PlayerPrefs score, resets Time.timeScale/NavMesh/RunRng, and suppresses the arena auto-bootstrap per test.

**Production code got visibility-only seams** (the diff above is the entirety of it): a few internal keywords plus the ArenaManager.suppressAutoBootstrap flag. No behavior changes, and EnemyWeapon's deliberate UnityEngine.Random usage was left alone per CLAUDE.md.

**scripts/run-tests.sh** [editmode|playmode|all] runs everything headless (results in results/tests/, gitignored), and README/CLAUDE.md now document the suite.
