### PR TITLE
Fail claude-review when findings are posted

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -42,3 +42,23 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 
+      # The code-review plugin posts findings as inline comments but always
+      # exits 0, so on its own the required check can never block a merge.
+      # Turn findings on the current revision into a red check. Caveat: the
+      # plugin skips PRs it has already commented on, so a later push goes
+      # green without re-review — the Unity test checks remain the hard gate.
+      - name: Fail when the review posted findings
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          findings=$(gh api "repos/$REPO/pulls/$PR/comments" --paginate \
+            --jq '[.[] | select((.user.login | startswith("claude")) and .commit_id == env.HEAD_SHA)] | length')
+          echo "claude inline findings on $HEAD_SHA: $findings"
+          if [ "$findings" -gt 0 ]; then
+            echo "::error::claude-review flagged $findings issue(s) on this revision — see the inline PR comments."
+            exit 1
+          fi
+


### PR DESCRIPTION
Makes the required claude-review check meaningful: after the review runs, a follow-up step counts inline comments left by claude on the current head SHA and fails the check if there are any.

Verified behavior of the plugin this builds on:
- Findings are posted as inline comments, but the action always exits 0 — without this step the required check can never turn red.
- The plugin skips PRs it has already commented on, so a push after a finding re-greens without re-review. The Unity test checks remain the hard gate.
- PRs modifying this workflow file skip review entirely (action anti-tamper validation) — including this one, which is why its claude-review check is green in seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)