### PR TITLE
Drop the range cap on hitscan weapons

### DIFF
--- a/Assets/Prefabs/Characters/Enemy.prefab
+++ b/Assets/Prefabs/Characters/Enemy.prefab
@@ -191,7 +191,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7bdf1522bcd810b128a55ac38ee03514, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  range: 100
   damage: 50
   muzzleFlash: {fileID: 5640015575482252821}
   hitEffect: {fileID: 2409495363409633794, guid: 4801bea02e36af382abf110c987937e9, type: 3}

--- a/Assets/Scripts/Weapon.cs
+++ b/Assets/Scripts/Weapon.cs
@@ -3,7 +3,6 @@ using UnityEngine;
 public abstract class Weapon : MonoBehaviour
 {
 
-    [SerializeField] float range = 100f;
     [SerializeField] float damage = 50f;
     [SerializeField] ParticleSystem muzzleFlash;
     [SerializeField] GameObject hitEffect;
@@ -13,6 +12,8 @@ public abstract class Weapon : MonoBehaviour
     [SerializeField] float tracerWidth = 0.04f;
     [SerializeField] float tracerDuration = 0.06f;
     [SerializeField] Transform muzzleOrigin;
+    [Tooltip("How far the tracer is drawn when the shot hits nothing. Visual only — it does not limit the hit test.")]
+    [SerializeField] float tracerMissDistance = 100f;
 
     static Material s_tracerMaterial;
 
@@ -33,10 +34,11 @@ public abstract class Weapon : MonoBehaviour
     {
         Vector3 origin = GetPosition();
         Vector3 direction = GetForward();
-        Vector3 endPoint = origin + direction * range;
+        Vector3 endPoint = origin + direction.normalized * tracerMissDistance;
         Health victim = null;
 
-        if (Physics.Raycast(origin, direction, out RaycastHit hit, range))
+        // Hitscan: no distance cap. The tracer length above is cosmetic.
+        if (Physics.Raycast(origin, direction, out RaycastHit hit, Mathf.Infinity))
         {
             endPoint = hit.point;
             CreateHitImpact(hit);

--- a/Assets/Tests/PlayMode/WeaponRangeTests.cs
+++ b/Assets/Tests/PlayMode/WeaponRangeTests.cs
@@ -1,0 +1,92 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+/// <summary>
+/// Hitscan weapons must have no distance cap (issue #18): line of sight is the
+/// only thing that decides whether a shot lands. Exercised through a test
+/// subclass so aim is exact — EnemyWeapon's spread would miss at these ranges.
+/// </summary>
+public class WeaponRangeTests : PlayModeTestBase
+{
+    class TestWeapon : Weapon
+    {
+        public Vector3 position;
+        public Vector3 forward = Vector3.forward;
+
+        protected override Vector3 GetPosition() => position;
+        protected override Vector3 GetForward() => forward;
+    }
+
+    TestWeapon weapon;
+
+    [SetUp]
+    public void SetUp()
+    {
+        SweepTracers(); // tracers self-destruct on a timer, which may outlive a test
+        weapon = Track(new GameObject("TestWeapon")).AddComponent<TestWeapon>();
+    }
+
+    static void SweepTracers()
+    {
+        foreach (LineRenderer tracer in Object.FindObjectsByType<LineRenderer>(FindObjectsInactive.Include, FindObjectsSortMode.None))
+        {
+            Object.DestroyImmediate(tracer.gameObject);
+        }
+    }
+
+    Health SpawnTargetAt(float distance)
+    {
+        GameObject target = Track(GameObject.CreatePrimitive(PrimitiveType.Cube));
+        target.transform.position = new Vector3(0f, 0f, distance);
+        Physics.SyncTransforms();
+        return target.AddComponent<Health>();
+    }
+
+    [UnityTest]
+    public IEnumerator Shot_DamagesTarget_AtAnyDistance()
+    {
+        foreach (float distance in new[] { 5f, 100f, 500f })
+        {
+            Health target = SpawnTargetAt(distance);
+            yield return new WaitForFixedUpdate();
+
+            weapon.Shoot();
+
+            Assert.That(target.health, Is.LessThan(target.maxHealth),
+                $"a hitscan shot must land at {distance} units with clear line of sight");
+            Object.DestroyImmediate(target.gameObject);
+        }
+    }
+
+    [UnityTest]
+    public IEnumerator Shot_IsBlockedByGeometry_NotByDistance()
+    {
+        Health target = SpawnTargetAt(500f);
+        GameObject wall = Track(GameObject.CreatePrimitive(PrimitiveType.Cube));
+        wall.transform.localScale = new Vector3(10f, 10f, 1f);
+        wall.transform.position = new Vector3(0f, 0f, 20f);
+        Physics.SyncTransforms();
+        yield return new WaitForFixedUpdate();
+
+        weapon.Shoot();
+
+        Assert.That(target.health, Is.EqualTo(target.maxHealth),
+            "removing the range cap must not let shots pass through walls");
+    }
+
+    [UnityTest]
+    public IEnumerator MissingShot_DrawsFiniteTracer()
+    {
+        yield return new WaitForFixedUpdate();
+
+        weapon.Shoot(); // empty scene: nothing to hit
+
+        var tracer = Object.FindAnyObjectByType<LineRenderer>();
+        Assert.That(tracer, Is.Not.Null, "a missing shot still draws a tracer");
+        Vector3 end = tracer.GetPosition(1);
+        Assert.That(float.IsFinite(end.z), Is.True, "an unbounded raycast must not produce an infinite tracer");
+        Assert.That(end.z, Is.EqualTo(100f).Within(0.01f), "default tracerMissDistance ahead of the muzzle");
+    }
+}

--- a/Assets/Tests/PlayMode/WeaponRangeTests.cs.meta
+++ b/Assets/Tests/PlayMode/WeaponRangeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d1117d2299810e58265f57722eba644b


### PR DESCRIPTION
Closes #18.

`Weapon.ProcessRaycast` capped the raycast at a serialized `range` field, so shots at the Enemy from across the arena did nothing. Removed the field and made the hit test unbounded; the tracer endpoint on a miss now comes from a separate `tracerMissDistance` (100, visual only). The stale `range: 100` line is dropped from the Enemy prefab; the value serialized in the binary scene for `PlayerWeapon` is ignored now that the field is gone.

New PlayMode fixture `WeaponRangeTests` shoots at targets 5/100/500 units out, checks a wall still blocks the shot, and checks a missed shot draws a finite tracer. Full suite passes locally.