### PR TITLE
Warp the NavMeshAgent when repositioning an agent-driven player

### DIFF
--- a/Assets/Scripts/ArenaManager.cs
+++ b/Assets/Scripts/ArenaManager.cs
@@ -256,17 +256,43 @@ public class ArenaManager : MonoBehaviour
         if (player == null) return;
         // Snap to the nearest walkable spot so the player never spawns inside a
         // wall/divider, whatever arena was generated.
-        Vector3 target = point;
-        if (NavMesh.SamplePosition(new Vector3(point.x, 1f, point.z), out NavMeshHit hit, 10f, NavMesh.AllAreas))
+        Vector3 ground = point;
+        bool onNavMesh = NavMesh.SamplePosition(new Vector3(point.x, 1f, point.z), out NavMeshHit hit, 10f, NavMesh.AllAreas);
+        if (onNavMesh) ground = hit.position;
+
+        // An agent-driven player (CombatantRig) is steered by a NavMeshAgent,
+        // which owns the transform from its own internal position — a raw
+        // positional write gets overridden and the body snaps back.
+        NavMeshAgent nav = player.GetComponent<NavMeshAgent>();
+        if (nav != null && nav.enabled && onNavMesh)
         {
-            target = hit.position + Vector3.up * 1.1f;
+            WarpPlayerAgent(nav, ground);
+            return;
         }
 
+        Vector3 target = onNavMesh ? ground + Vector3.up * 1.1f : point;
         CharacterController cc = player.GetComponent<CharacterController>();
         bool wasEnabled = cc != null && cc.enabled;
         if (cc != null) cc.enabled = false; // CharacterController fights direct position writes.
         player.transform.position = target;
         if (cc != null) cc.enabled = wasEnabled;
+    }
+
+    // Same pattern as EnemyBehavior.EnsureOnNavMesh: Warp is the normal path,
+    // but it no-ops when the native agent lost its mesh (arena rebuilt under
+    // it), and toggling the component forces a clean re-creation.
+    static void WarpPlayerAgent(NavMeshAgent nav, Vector3 target)
+    {
+        if (nav.isOnNavMesh) nav.ResetPath(); // drop last round's destination
+        if (nav.Warp(target) && nav.isOnNavMesh) return;
+
+        nav.enabled = false;
+        nav.transform.position = target;
+        nav.enabled = true;
+        if (!nav.isOnNavMesh)
+        {
+            Debug.LogWarning($"[ArenaManager] Could not place the player agent on the NavMesh at {target}.", nav);
+        }
     }
 
     void BakeNavMesh()

--- a/Assets/Tests/PlayMode/ArenaSeedingTests.cs
+++ b/Assets/Tests/PlayMode/ArenaSeedingTests.cs
@@ -104,6 +104,63 @@ public class ArenaSeedingTests : PlayModeTestBase
         }
     }
 
+    // Far outside every arena, so "was the player actually moved?" is unambiguous.
+    static readonly Vector3 OffArena = new Vector3(500f, 0f, 500f);
+
+    GameObject CreatePlayerBody(bool agentDriven)
+    {
+        GameObject player = Track(GameObject.CreatePrimitive(PrimitiveType.Capsule));
+        player.name = "TestPlayer";
+        player.tag = "Player";
+        player.transform.position = OffArena;
+        if (agentDriven) player.AddComponent<NavMeshAgent>();
+        else player.AddComponent<CharacterController>();
+        Physics.SyncTransforms();
+        return player;
+    }
+
+    [UnityTest]
+    public IEnumerator RepositioningAnAgentDrivenPlayer_Sticks()
+    {
+        ArenaManager manager = CreateManager(4242, forcedIndex: 0);
+        GameObject player = CreatePlayerBody(agentDriven: true);
+        var nav = player.GetComponent<NavMeshAgent>();
+
+        manager.RepositionPlayerAtRandomPoint();
+        Vector3 placed = player.transform.position;
+        Assert.That(nav.isOnNavMesh, Is.True, $"player agent left off the NavMesh at {placed}");
+        Assert.That(Vector3.Distance(placed, OffArena), Is.GreaterThan(1f), "player was not moved at all");
+
+        // The regression: a raw transform write leaves the NavMeshAgent's
+        // internal position behind, and the next agent update snaps the body
+        // back to where it was.
+        yield return null;
+        yield return null;
+        // Horizontal only: the agent legitimately lifts the body by its
+        // baseOffset on its first update.
+        Vector2 before = new Vector2(placed.x, placed.z);
+        Vector2 after = new Vector2(player.transform.position.x, player.transform.position.z);
+        Assert.That(Vector2.Distance(before, after), Is.LessThan(0.5f),
+            $"agent-driven player drifted back from {placed} to {player.transform.position}");
+    }
+
+    [UnityTest]
+    public IEnumerator RepositioningAHumanPlayer_StillLandsOnTheArena()
+    {
+        ArenaManager manager = CreateManager(4242, forcedIndex: 0);
+        GameObject player = CreatePlayerBody(agentDriven: false);
+
+        manager.RepositionPlayerAtRandomPoint();
+        yield return null;
+
+        Vector3 placed = player.transform.position;
+        Assert.That(Vector3.Distance(placed, OffArena), Is.GreaterThan(1f), "player was not moved at all");
+        Assert.That(NavMesh.SamplePosition(placed, out NavMeshHit _, 2f, NavMesh.AllAreas), Is.True,
+            $"player was placed off the NavMesh at {placed}");
+        Assert.That(player.GetComponent<CharacterController>().enabled, Is.True,
+            "the CharacterController must be re-enabled after the move");
+    }
+
     [UnityTest]
     public IEnumerator EnemySpawn_LandsOnNavMesh_AwayFromThePlayer()
     {


### PR DESCRIPTION
Closes #28.

`ArenaManager.MovePlayerTo` repositioned the player with a direct `transform.position` write. That is fine for the human driver, but `CombatantRig`'s agent driver puts a live `NavMeshAgent` on the same body, and the agent drives the transform from its own internal position — the player snapped back and was left off the NavMesh (the `CharacterController` guard is a no-op there, since agent mode already disabled it).

Now `MovePlayerTo` warps the agent when the player has an enabled `NavMeshAgent` and the target sampled onto the NavMesh, clearing the old path first, and falls back to toggling the component when `Warp` no-ops — the pattern `EnemyBehavior.EnsureOnNavMesh` already uses. The human path is untouched.

Two PlayMode tests in `ArenaSeedingTests`: an agent-driven player stays where it was put (and is on the NavMesh), and the human player still lands on the arena with its `CharacterController` re-enabled. Reverting the fix fails the first one.

`scripts/run-tests.sh all`: EditMode 72/72, PlayMode 47/47.