### PR TITLE
Trim the auto-generated comments across the codebase

### DIFF
--- a/Assets/Scripts/ArenaManager.cs
+++ b/Assets/Scripts/ArenaManager.cs
@@ -4,19 +4,13 @@ using UnityEngine.AI;
 using UnityEngine.SceneManagement;
 using Unity.AI.Navigation;
 
-/// <summary>
-/// Procedurally builds one of several FPS arenas at runtime and bakes a fresh
-/// NavMesh over it. On <see cref="Awake"/> it removes any static arena baked
-/// into the scene (the "Arena" root) so generated geometry is the only thing
-/// present, picks a random layout, builds it from primitive cubes with
-/// contrasting URP materials, and bakes the NavMesh so the enemy NavMeshAgent
-/// has somewhere to walk.
-///
-/// Runs very early (<see cref="DefaultExecutionOrder"/> -10000) so the NavMesh
-/// exists before <see cref="EnemyBehavior"/> / <see cref="EnemyAgent"/> try to
-/// spawn the enemy on it. <see cref="EnemyBehavior"/> queries
-/// <see cref="Current"/> for valid spawn points instead of hard-coded bounds.
-/// </summary>
+// Builds one of several FPS arenas from primitive cubes at runtime and bakes a
+// fresh NavMesh over it — the scene is force-binary serialized, so level
+// geometry can't be authored and reviewed as text. Any static "Arena" root the
+// scene still carries is removed first.
+//
+// The execution order below runs this before EnemyBehavior/EnemyAgent, so the
+// NavMesh exists by the time they try to spawn the enemy on it.
 [DefaultExecutionOrder(-10000)]
 public class ArenaManager : MonoBehaviour
 {
@@ -42,26 +36,20 @@ public class ArenaManager : MonoBehaviour
     // have to raycast-search the world.
     readonly List<Collider> coverColliders = new List<Collider>();
 
-    /// <summary>Half the floor size along X (distance from center to the inner wall face).</summary>
+    // Half the floor size, i.e. center to the inner wall face.
     public float HalfExtentX { get; private set; }
-    /// <summary>Half the floor size along Z.</summary>
     public float HalfExtentZ { get; private set; }
-    /// <summary>Where the player should be placed for the current arena.</summary>
     public Vector3 PlayerSpawn { get; private set; }
-    /// <summary>Index of the arena that was built this session.</summary>
     public int ActiveArenaIndex { get; private set; }
-    /// <summary>Human-readable name of the active arena.</summary>
     public string ActiveArenaName { get; private set; }
 
     public const int ArenaCount = 5;
 
     // Fallback bootstrap: if no ArenaManager was placed in the scene, spawn
     // one so arenas still generate out of the box. AfterSceneLoad only fires
-    // for the FIRST scene of a session, but the manager and its generated
-    // arena die with every SceneManager.LoadScene — without the sceneLoaded
-    // hook, rounds 2+ had no manager at all: no re-roll, and the old static
-    // "Arena" root baked into the scene was never removed, so every round
-    // after the first showed the same hand-authored arena.
+    // for the FIRST scene of a session, but the manager dies with every
+    // SceneManager.LoadScene — hence the sceneLoaded hook, without which
+    // rounds 2+ get no manager, no re-roll and the stale static "Arena" root.
     [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
     static void AutoBootstrap()
     {
@@ -121,18 +109,14 @@ public class ArenaManager : MonoBehaviour
 
     // ---------------------------------------------------------------- bounds
 
-    /// <summary>The floor surface sits at y = 0; anything sampled noticeably
-    /// above it is a platform/rampart/stair/crate top rather than the main
-    /// floor. Spawns are kept at or below this height so actors land on the
-    /// open floor where they are visible, not perched on top of cover.</summary>
+    // The floor sits at y = 0, so anything sampled noticeably above it is a
+    // platform/rampart/stair/crate top. Spawns stay at or below this height:
+    // actors belong on the open floor, not perched out of sight on cover.
     const float GroundLevelMaxY = 0.6f;
 
-    /// <summary>
-    /// A random point on the main floor of the baked NavMesh, comfortably
-    /// inside the arena walls. Avoids the tops of raised cover so the enemy
-    /// never spawns out of sight on a platform. Always returns a valid on-mesh
-    /// point once a NavMesh is baked (never the off-mesh origin).
-    /// </summary>
+    // A random floor-level point on the baked NavMesh, comfortably inside the
+    // walls. Once a NavMesh is baked this always returns an on-mesh point,
+    // never the off-mesh origin.
     public Vector3 RandomGroundPoint()
     {
         float marginX = Mathf.Max(2f, HalfExtentX - 2f);
@@ -160,7 +144,7 @@ public class ArenaManager : MonoBehaviour
         return Vector3.zero;
     }
 
-    /// <summary>How far apart two actors can realistically be in this arena.</summary>
+    // How far apart two actors can realistically be in this arena.
     public float SpawnSeparationCap => Mathf.Min(HalfExtentX, HalfExtentZ) * 1.4f;
 
     // ----------------------------------------------------------------- cover
@@ -168,11 +152,10 @@ public class ArenaManager : MonoBehaviour
     const float EyeHeight = 1f;          // matches EnemyBehavior's sight-ray origin
     const float CoverStandOff = 1.2f;    // how far behind the cover face to stand
 
-    /// <summary>Nearest walkable point hidden from <paramref name="breakLosFrom"/>
-    /// and reachable from <paramref name="from"/>. False when this layout offers
-    /// none — the caller must fall back to another action. Pass the threat's own
-    /// sight mask (<see cref="EnemyBehavior.SightObstacleMask"/>), or a point
-    /// can come back "hidden" behind geometry the threat sees straight through.</summary>
+    // Nearest walkable point hidden from breakLosFrom and reachable from `from`.
+    // False when this layout offers none — the caller must fall back to another
+    // action. The mask must be the threat's own (EnemyBehavior.SightObstacleMask),
+    // or a point comes back "hidden" behind geometry the threat sees through.
     public bool NearestCoverPoint(Vector3 from, Vector3 breakLosFrom, LayerMask sightObstacleMask, out Vector3 coverPoint)
     {
         coverPoint = default;
@@ -240,13 +223,9 @@ public class ArenaManager : MonoBehaviour
         }
     }
 
-    /// <summary>
-    /// Teleport the player to a random walkable point. Called from
-    /// <see cref="Start"/> every round (all modes) and by
-    /// <see cref="EnemyAgent"/> on episode begin during training, so player
-    /// spawns are distributed across the arena instead of clustering at a
-    /// fixed spot or wherever the last episode ended.
-    /// </summary>
+    // Called from Start every round (all modes) and by EnemyAgent on episode
+    // begin during training, so spawns spread across the arena instead of
+    // clustering at a fixed spot or wherever the last episode ended.
     public void RepositionPlayerAtRandomPoint()
     {
         MovePlayerTo(RandomGroundPoint());
@@ -340,10 +319,8 @@ public class ArenaManager : MonoBehaviour
         Material crate = MakeMat(new Color(0.88f, 0.80f, 0.30f)); // yellow
         BuildFloorAndWalls(20f, 20f, floor, wall);
 
-        // Central house with a door facing south (toward the player spawn).
         House(new Vector3(0f, 0f, 2f), 11f, 9f, 4f, 3f, cover);
 
-        // Corner crate stacks for cover.
         foreach (Vector3 c in new[]
         {
             new Vector3(-12f, 0f, 10f), new Vector3(12f, 0f, 10f),
@@ -354,7 +331,6 @@ public class ArenaManager : MonoBehaviour
             Box("Crate", c + new Vector3(1.6f, 1f, 0.4f), new Vector3(1.6f, 2f, 1.6f), crate);
         }
 
-        // Two low flanking walls.
         Box("LowWall", new Vector3(-7f, 0.75f, -8f), new Vector3(6f, 1.5f, 0.8f), cover);
         Box("LowWall", new Vector3(7f, 0.75f, -8f), new Vector3(6f, 1.5f, 0.8f), cover);
     }
@@ -369,7 +345,6 @@ public class ArenaManager : MonoBehaviour
         Material crate = MakeMat(new Color(0.90f, 0.85f, 0.80f)); // bone
         BuildFloorAndWalls(14f, 14f, floor, wall);
 
-        // Raised platforms in NE and SW corners, with stairs leading up.
         Platform(new Vector3(9f, 0f, 9f), 7f, 7f, 2.5f, cover);
         Stairs(new Vector3(9f, 0f, 4.5f), Vector3.forward, 10, 0.25f, 0.55f, 4f, cover);
 
@@ -393,15 +368,13 @@ public class ArenaManager : MonoBehaviour
         Material barrier = MakeMat(new Color(0.60f, 0.60f, 0.65f)); // steel
         BuildFloorAndWalls(30f, 30f, floor, wall);
 
-        // Two towers (tall houses) with doorways facing the center.
         House(new Vector3(-15f, 0f, 8f), 13f, 13f, 8f, 4f, tower);
         House(new Vector3(15f, 0f, -8f), 13f, 13f, 8f, 4f, tower);
 
-        // Long mid-field sightline blockers.
+        // Long mid-field sightline blockers, or this arena is one big open shot.
         Box("Barrier", new Vector3(0f, 1.5f, 14f), new Vector3(16f, 3f, 1f), barrier);
         Box("Barrier", new Vector3(0f, 1.5f, -14f), new Vector3(16f, 3f, 1f), barrier);
 
-        // Crate clusters around the towers for short cover.
         Box("Crate", new Vector3(-6f, 1f, -6f), new Vector3(2.5f, 2f, 2.5f), crate);
         Box("Crate", new Vector3(6f, 1f, 6f), new Vector3(2.5f, 2f, 2.5f), crate);
         Box("Crate", new Vector3(20f, 1f, 18f), new Vector3(2.5f, 2f, 2.5f), crate);
@@ -429,7 +402,6 @@ public class ArenaManager : MonoBehaviour
         Box("Maze", new Vector3(-4f, h / 2, -10f), new Vector3(16f, h, t), maze);
         Box("Maze", new Vector3(13f, h / 2, -6f), new Vector3(12f, h, t), maze);
 
-        // Decorative pillars at junctions, also useful cover.
         foreach (Vector3 p in new[]
         {
             new Vector3(-2f, 0f, 10f), new Vector3(8f, 0f, 4f),
@@ -450,10 +422,8 @@ public class ArenaManager : MonoBehaviour
         Material crate = MakeMat(new Color(0.88f, 0.78f, 0.55f)); // tan
         BuildFloorAndWalls(28f, 18f, floor, wall);
 
-        // Raised walkways (ramparts) along the east and west edges.
         Platform(new Vector3(-25f, 0f, 0f), 5f, 30f, 2.5f, rampart);
         Platform(new Vector3(25f, 0f, 0f), 5f, 30f, 2.5f, rampart);
-        // Stairs up to each rampart from mid-field.
         Stairs(new Vector3(-21f, 0f, 0f), Vector3.left, 9, 0.28f, 0.55f, 5f, rampart);
         Stairs(new Vector3(21f, 0f, 0f), Vector3.right, 9, 0.28f, 0.55f, 5f, rampart);
 
@@ -461,7 +431,6 @@ public class ArenaManager : MonoBehaviour
         Box("Divider", new Vector3(0f, 1.75f, 9f), new Vector3(1f, 3.5f, 14f), wall);
         Box("Divider", new Vector3(0f, 1.75f, -9f), new Vector3(1f, 3.5f, 14f), wall);
 
-        // Crates for ground-level cover.
         Box("Crate", new Vector3(-10f, 1f, 6f), new Vector3(2.5f, 2f, 2.5f), crate);
         Box("Crate", new Vector3(10f, 1f, -6f), new Vector3(2.5f, 2f, 2.5f), crate);
         Box("Crate", new Vector3(8f, 1f, 8f), new Vector3(2.5f, 2f, 2.5f), crate);

--- a/Assets/Scripts/AssemblyInfo.cs
+++ b/Assets/Scripts/AssemblyInfo.cs
@@ -1,8 +1,6 @@
 using System.Runtime.CompilerServices;
 
-// The test assemblies drive internal seams (RunRng.ResetForNewRun,
-// ArenaManager.suppressAutoBootstrap, TelemetryLogger.SwapWriter/RescanHealths,
-// serialized config fields) that the game's public API deliberately does not
-// expose.
+// The test assemblies drive internal seams — reset hooks, bootstrap
+// suppression, serialized config — that the public API deliberately withholds.
 [assembly: InternalsVisibleTo("URLNPC.Tests.EditMode")]
 [assembly: InternalsVisibleTo("URLNPC.Tests.PlayMode")]

--- a/Assets/Scripts/CombatantRig.cs
+++ b/Assets/Scripts/CombatantRig.cs
@@ -5,30 +5,16 @@ using Unity.MLAgents;
 using Unity.MLAgents.Actuators;
 using Unity.MLAgents.Policies;
 
-/// <summary>
-/// Makes the player side interchangeable (issue #10): the same body —
-/// capsule + <see cref="Health"/> + weapon + camera anchor, tag "Player" —
-/// can be driven by a Human (StarterAssets first-person controller +
-/// <see cref="PlayerWeapon"/>) or by an Agent (ML-Agents
-/// <see cref="PlayerAgent"/> + NavMeshAgent + <see cref="EnemyWeapon"/>-style
-/// firing). Exactly one driver is active per run.
-///
-/// The scene is force-binary serialized, so the Agent driver's components
-/// can't be authored in the scene file — this rig composes them at runtime
-/// on the existing player body, the same trick <c>ArenaManager</c> and
-/// <c>GameManager</c> already use. The Human driver is whatever the scene
-/// already carries; in Human mode the rig leaves it alone.
-///
-/// Driver selection, highest priority first:
-///  1. command line: <c>-playerDriver agent</c> / <c>-playerDriver human</c>
-///  2. <see cref="DriverOverride"/> (set from code, e.g. a menu/GameManager,
-///     before the scene loads)
-///  3. the <c>driver</c> Inspector field (default Human)
-///
-/// <see cref="Health"/>, the "Player" tag and <c>GameManager.ProcessDeath</c>
-/// are untouched by the switch, so win/loss handling works identically for
-/// either driver.
-/// </summary>
+// Makes the player side interchangeable (issue #10): the same body can be
+// driven by a Human (the StarterAssets controller authored in the scene) or by
+// an Agent. Exactly one driver is active per run.
+//
+// The scene is force-binary serialized, so the agent driver's components can't
+// be authored there — the rig composes them at runtime on the existing player
+// body. Human mode touches nothing.
+//
+// Health, the "Player" tag and GameManager.ProcessDeath are untouched by the
+// switch, so win/loss handling is identical for either driver.
 [DefaultExecutionOrder(-100)] // decide the driver before any driver's Start runs
 public class CombatantRig : MonoBehaviour
 {
@@ -44,27 +30,21 @@ public class CombatantRig : MonoBehaviour
     [SerializeField] int agentTeamId = 1;
     [SerializeField] float agentMoveSpeed = 4f;
 
-    /// <summary>Code-level driver selection (e.g. from a future menu or GameManager). Set before the scene loads; survives scene reloads.</summary>
+    // Set from code (a future menu, say) before the scene loads; survives reloads.
     public static DriverKind? DriverOverride;
 
-    /// <summary>The driver that actually won the selection this run.</summary>
     public DriverKind ActiveDriver { get; private set; }
 
-    /// <summary>
-    /// The human-driver components the agent path silences, named as strings
-    /// because they cannot be referenced at compile time (see
-    /// <see cref="EnableAgentDriver"/>). Exposed so the test suite can assert
-    /// against the names actually used here rather than a second copy of them.
-    /// </summary>
+    // The human-driver components the agent path silences, as strings because
+    // they can't be referenced at compile time (see EnableAgentDriver).
+    // Internal so the tests assert against these names, not a second copy.
     internal static readonly string[] HumanDriverTypeNames =
     {
         "FirstPersonController",
         "StarterAssetsInputs",
     };
 
-    // The scene is binary, so the rig can't be added to the player in the
-    // editor by editing text — attach it at runtime if it isn't there.
-    // AfterSceneLoad runs after scene Awakes but before Starts, which is
+    // AfterSceneLoad runs after the scene's Awakes but before Starts, which is
     // early enough to silence the human driver before it initializes.
     [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
     static void AutoBootstrap()
@@ -90,7 +70,6 @@ public class CombatantRig : MonoBehaviour
 
     void EnableAgentDriver()
     {
-        // --- 1. Silence every input-driven component on the body. ----------
         // StarterAssets lives in Assembly-CSharp, which auto-references this
         // assembly (URLNPC) — so URLNPC can't reference it back and the two
         // controller types can't be named at compile time. Match by type name.
@@ -101,8 +80,8 @@ public class CombatantRig : MonoBehaviour
         CharacterController cc = GetComponent<CharacterController>();
         if (cc != null) cc.enabled = false;
 
-        // --- 2. NavMesh locomotion (ArenaManager baked the mesh in Awake,
-        // execution order -10000, so it already exists). -------------------
+        // ArenaManager baked the mesh in Awake at execution order -10000, so
+        // it already exists by the time this agent needs it.
         NavMeshAgent nav = gameObject.AddComponent<NavMeshAgent>();
         nav.speed = agentMoveSpeed;
         nav.angularSpeed = 720f;
@@ -113,22 +92,20 @@ public class CombatantRig : MonoBehaviour
             nav.height = cc.height;
         }
 
-        // --- 3. Combat stack: reuse the enemy scripts on the player body.
-        // Weapon must exist before EnemyBehavior — its Awake caches it. -----
+        // The weapon must exist before EnemyBehavior — its Awake caches it.
         gameObject.AddComponent<EnemyWeapon>();
         EnemyBehavior behavior = gameObject.AddComponent<EnemyBehavior>();
         behavior.targetTag = "NPC"; // this combatant hunts the enemy
         GameObject npc = GameObject.FindWithTag("NPC");
         if (npc != null) behavior.target = npc.transform;
 
-        // --- 4. ML-Agents plumbing. BehaviorParameters must exist and be
-        // configured BEFORE the Agent component initializes against it. -----
-        // (Check Health first: PlayerAgent's RequireComponent would silently
-        // auto-add a fresh one and mask a mis-set-up body.)
+        // Check Health before adding PlayerAgent: its RequireComponent would
+        // silently auto-add a fresh one and mask a mis-set-up body.
         if (GetComponent<Health>() == null)
         {
             Debug.LogError("[CombatantRig] Player body has no Health on its root — the agent driver can't take damage or die properly.");
         }
+        // Configured before PlayerAgent is added: the Agent initializes against it.
         BehaviorParameters bp = gameObject.AddComponent<BehaviorParameters>();
         bp.BehaviorName = agentBehaviorName;
         bp.TeamId = agentTeamId;

--- a/Assets/Scripts/CounterData.cs
+++ b/Assets/Scripts/CounterData.cs
@@ -2,10 +2,8 @@ using UnityEngine;
 
 public static class CounterData
 {
-    // PlayerPrefs keys — backs the score with Unity's on-disk store so the
-    // tally survives quitting the game (Editor Play sessions and standalone
-    // builds alike). This lets you stop and resume a training run later
-    // without losing the win/loss count.
+    // PlayerPrefs is on-disk, so the tally survives quitting the game — a
+    // training run can be stopped and resumed without losing the count.
     const string UserPointsKey = "URLNPC.userPoints";
     const string NpcPointsKey = "URLNPC.npcPoints";
     const string DrawsKey = "URLNPC.draws";
@@ -37,16 +35,13 @@ public static class CounterData
         return PlayerPrefs.GetInt(DrawsKey, 0);
     }
 
-    // Round clock ran out with both combatants alive — nobody scores.
     public static void Draw()
     {
         PlayerPrefs.SetInt(DrawsKey, readDraws() + 1);
         PlayerPrefs.Save();
     }
 
-    // Manual reset — wire this to a UI button or call it from a menu when you
-    // want to start a fresh tally. Nothing zeroes the score automatically
-    // anymore, so the count persists until you clear it here.
+    // The only thing that ever zeroes the tally; nothing clears it automatically.
     public static void ResetScores()
     {
         PlayerPrefs.DeleteKey(UserPointsKey);

--- a/Assets/Scripts/DriverSelector.cs
+++ b/Assets/Scripts/DriverSelector.cs
@@ -1,25 +1,17 @@
-/// <summary>
-/// Which driver takes the player body, as pure logic — engine-free so the
-/// priority chain is unit-testable without play mode or a real command line.
-/// <see cref="CombatantRig"/> owns the adapter half: it passes
-/// <c>System.Environment.GetCommandLineArgs()</c>, the static
-/// <see cref="CombatantRig.DriverOverride"/> and its serialized field in.
-/// </summary>
+// Which driver takes the player body, as pure logic — engine-free so the
+// priority chain is testable without play mode or a real command line.
+// CombatantRig is the adapter half.
 public static class DriverSelector
 {
-    /// <summary>Command line flag: <c>-playerDriver human|agent</c>.</summary>
     public const string CommandLineArg = "-playerDriver";
 
-    /// <summary>
-    /// Resolve the driver, highest priority first: command line, then a
-    /// code-level override, then the Inspector default.
-    ///
-    /// The command line scan is deliberately lenient — the editor and player
-    /// are launched with plenty of arguments this code knows nothing about, so
-    /// an unparseable occurrence (unrecognized value, or the flag appearing as
-    /// the very last argument with nothing after it) is skipped rather than
-    /// treated as an error. The first occurrence that names a real driver wins.
-    /// </summary>
+    // Highest priority first: command line, code-level override, Inspector
+    // default.
+    //
+    // The command line scan is deliberately lenient — the editor and player are
+    // launched with plenty of arguments this code knows nothing about, so an
+    // unparseable occurrence is skipped rather than treated as an error. The
+    // first occurrence naming a real driver wins.
     public static CombatantRig.DriverKind Resolve(
         string[] args,
         CombatantRig.DriverKind? codeOverride,

--- a/Assets/Scripts/EnemyAgent.cs
+++ b/Assets/Scripts/EnemyAgent.cs
@@ -40,12 +40,11 @@ public class EnemyAgent : Agent
 
     public override void Initialize()
     {
-        // The GameManager round clock is the single owner of time-based
-        // episode termination (timeout penalty + draw). A nonzero
-        // Agent.MaxStep would silently reset the episode before the clock
-        // fires — the binary FPS scene carries a stale MaxStep of 5000
-        // (~100 s, shorter than the 120 s round), which made timeouts
-        // restart the round in place without ever counting a draw.
+        // The round clock is the single owner of time-based episode
+        // termination. A nonzero MaxStep silently resets the episode before the
+        // clock fires — the binary FPS scene carries a stale 5000 (~100 s,
+        // shorter than the round), which made timeouts restart the round in
+        // place and never count a draw.
         if (MaxStep != 0)
         {
             Debug.LogWarning($"[EnemyAgent] Overriding serialized MaxStep {MaxStep} -> 0; the round clock owns episode timeout.");
@@ -57,9 +56,8 @@ public class EnemyAgent : Agent
         selfHealth.OnDamaged += HandleSelfDamaged;
         selfHealth.OnDied += HandleSelfDied;
 
-        // Snapshot of the serialized tunables, taken once per play session —
-        // tweak them between runs, not mid-play. (The event rewards below
-        // still read their fields live.)
+        // Snapshot taken once per play session, so these tunables only take
+        // effect between runs. (The event rewards below still read live.)
         stepRewards = new RewardComputer
         {
             aliveRewardPerStep = aliveRewardPerStep,
@@ -72,7 +70,7 @@ public class EnemyAgent : Agent
     void Update()
     {
         // Sensory contract (issue #9): target info reaches the policy only
-        // through PerceptionMemory, never straight off the target transform.
+        // through PerceptionMemory, never off the target transform.
         targetInSight = behavior.Perception != null && behavior.Perception.CurrentlyVisible;
         canAttack = behavior.ReadCanAttack();
         float maxHp = selfHealth.maxHealth <= 0f ? 1f : selfHealth.maxHealth;
@@ -121,7 +119,7 @@ public class EnemyAgent : Agent
     {
         if (episodeEnding) return;
 
-        // True-state read is fine here: reward computation is environment
+        // A true-state read is fine here: reward computation is environment
         // code, not a policy input (sensory contract, issue #9).
         float distanceToTarget = behavior.DistanceToTarget();
 
@@ -155,23 +153,20 @@ public class EnemyAgent : Agent
             ArenaManager.Current.RepositionPlayerAtRandomPoint();
         }
         if (behavior != null) behavior.ResetState();
-        // Every episode gets a full round clock — during training episodes
-        // reset without a scene reload, so the clock must be rearmed here.
+        // Training episodes reset without a scene reload, so the clock has to
+        // be rearmed here to give each one a full budget.
         if (gameManager == null) gameManager = FindAnyObjectByType<GameManager>();
         if (gameManager != null) gameManager.ResetRoundClock();
-        // Make every episode attributable to its run seed in TensorBoard.
-        // (The authoritative full-precision record is RunRng's startup log.)
+        // Makes every episode attributable to its run seed in TensorBoard.
         if (Academy.IsInitialized)
         {
             Academy.Instance.StatsRecorder.Add("Run/Seed", RunRng.Seed);
         }
     }
 
-    /// <summary>
-    /// Called by <see cref="GameManager"/> when the round clock runs out.
-    /// Timeout is a draw: both sides take a small penalty (stalling should
-    /// not pay off) and the episode ends without a winner.
-    /// </summary>
+    // Called by GameManager when the round clock runs out. A timeout is a draw:
+    // both sides take a small penalty so stalling doesn't pay off, and the
+    // episode ends without a winner.
     public void OnRoundTimeout()
     {
         if (episodeEnding) return;

--- a/Assets/Scripts/EnemyBehavior.cs
+++ b/Assets/Scripts/EnemyBehavior.cs
@@ -21,16 +21,13 @@ public class EnemyBehavior : MonoBehaviour
     Health enemyHealth;
     bool canAttack = true;
 
-    /// <summary>
-    /// The only source of target info for the NPC brain (sensory contract,
-    /// issue #9). Auto-added at runtime because the Enemy prefab is binary
-    /// serialized and can't gain new components via a text edit.
-    /// </summary>
+    // The only source of target info for the NPC brain (sensory contract,
+    // issue #9). Auto-added in Awake because the Enemy prefab is binary
+    // serialized and can't gain new components via a text edit.
     public PerceptionMemory Perception { get; private set; }
 
-    /// <summary>What this combatant's sight ray can be blocked by. Cover
-    /// queries must run against the same mask (see
-    /// <see cref="ArenaManager.NearestCoverPoint"/>).</summary>
+    // What this combatant's sight ray can be blocked by. Cover queries must run
+    // against the same mask (ArenaManager.NearestCoverPoint).
     public LayerMask SightObstacleMask => sightObstacleMask;
 
     void Awake()
@@ -58,10 +55,9 @@ public class EnemyBehavior : MonoBehaviour
     {
         DidShoot = false;
         Perception.Refresh();
-        // Aim at the last-seen position, never the live one — while the
-        // target is visible they are the same thing; behind cover the shot
-        // goes where the NPC *believes* the player is (and eats the
-        // wastedShotPenalty if it's wrong).
+        // Aim at the last-seen position, never the live one. While the target
+        // is visible they are the same; behind cover the shot goes where the
+        // NPC believes the player is, and eats the wastedShotPenalty if wrong.
         if (canAttack && Perception.HasEverSeen)
         {
             Vector3 aim = Perception.LastSeenPosition;
@@ -77,10 +73,8 @@ public class EnemyBehavior : MonoBehaviour
     {
         if (!navMeshAgent.isOnNavMesh) return;
         Perception.Refresh();
-        // Navigate to where the target was last seen, not where they truly
-        // are — with the player behind a wall the enemy heads to the corner
-        // it lost sight at instead of wallhack-tracking. Never seen anyone?
-        // Then there is nothing to chase.
+        // Last-seen, not true position: with the player behind a wall the enemy
+        // heads for the corner it lost sight at instead of wallhack-tracking.
         if (Perception.HasEverSeen)
         {
             navMeshAgent.SetDestination(Perception.LastSeenPosition);
@@ -181,8 +175,8 @@ public class EnemyBehavior : MonoBehaviour
 
     Vector3 GetRandomPositionInMap()
     {
-        // Prefer a point sampled from the procedurally generated arena's NavMesh
-        // so spawns stay inside whatever arena was selected this round.
+        // Sample the generated arena's NavMesh so spawns stay inside whatever
+        // layout was selected this round; the bounds below are a bare fallback.
         if (ArenaManager.Current != null) return ArenaManager.Current.RandomGroundPoint();
 
         float newX = RunRng.Range(RunRng.Stream.Spawn, -60f, 60f);
@@ -219,10 +213,8 @@ public class EnemyBehavior : MonoBehaviour
         return true;
     }
 
-    // True distance to the live target position. ENVIRONMENT-SIDE ONLY: used
-    // by EnemyAgent for reward computation (tooClose penalty), which is
-    // allowed to read true state. Never feed this to observations or actions
-    // — the brain goes through PerceptionMemory.
+    // ENVIRONMENT-SIDE ONLY. Reward computation may read true state; never feed
+    // this to observations or actions — the brain goes through PerceptionMemory.
     public float DistanceToTarget()
     {
         if (target == null) return Mathf.Infinity;

--- a/Assets/Scripts/EnemyWeapon.cs
+++ b/Assets/Scripts/EnemyWeapon.cs
@@ -15,9 +15,9 @@ public class EnemyWeapon : Weapon
     {
         Vector3 forward = gameObject.transform.forward;
         if (aimSpreadDegrees <= 0f) return forward;
-        // Random cone around the aim vector. Box-Muller-ish: pick a random
-        // axis perpendicular to forward, rotate by a random angle in
-        // [-aimSpreadDegrees, +aimSpreadDegrees].
+        // Deliberately UnityEngine.Random, not RunRng: this is drawn a
+        // policy-dependent number of times, which would desync the
+        // reproducible streams between runs.
         Vector3 perp = Vector3.Cross(forward, Random.onUnitSphere).normalized;
         if (perp.sqrMagnitude < 1e-4f) perp = Vector3.up;
         float angle = Random.Range(-aimSpreadDegrees, aimSpreadDegrees);

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -16,11 +16,7 @@ public class GameManager : MonoBehaviour
     [Tooltip("Optional HUD text for the clock. Left empty (the scene is binary serialized), one is created at runtime on the HUD canvas.")]
     [SerializeField] TMP_Text timerText;
 
-    /// <summary>
-    /// Seconds left on the round clock. Queryable from anywhere — this is
-    /// the "tiempo restante de la ronda" input for the future
-    /// GameStateSnapshot / LLM context.
-    /// </summary>
+    // Public because the future GameStateSnapshot / LLM context needs it.
     public float RemainingRoundTime => roundClock.Remaining;
 
     readonly RoundClock roundClock = new RoundClock();
@@ -46,29 +42,25 @@ public class GameManager : MonoBehaviour
         if (expired) ProcessTimeout();
     }
 
-    /// <summary>
-    /// Rearm the clock. Called on round start and by EnemyAgent.OnEpisodeBegin,
-    /// so during training every episode gets a full time budget without a
-    /// scene reload. Idempotent — multiple agents resetting in the same
-    /// frame is fine.
-    /// </summary>
+    // Also called by EnemyAgent.OnEpisodeBegin, so training episodes get a full
+    // time budget without a scene reload. Idempotent: several agents resetting
+    // in the same frame is fine.
     public void ResetRoundClock()
     {
         roundClock.Duration = roundDurationSeconds;
         roundClock.Reset();
     }
 
-    // Clears the persisted win/loss tally. Public so it can also be wired to
-    // an OnClick in the Inspector if you ever rebuild the canvas by hand.
+    // Public so it can also be wired to an OnClick in the Inspector, if the
+    // canvas is ever rebuilt by hand.
     public void ResetScore()
     {
         CounterData.ResetScores();
     }
 
-    // The FPS scene is force-binary serialized, so we can't author button
-    // wiring in the scene file — build the "Reset Score" button in code and
-    // parent it to the end-of-round canvas. As a child of that canvas it
-    // shows/hides automatically with the canvas's enabled state.
+    // The FPS scene is force-binary serialized, so button wiring can't be
+    // authored there. Parented to the end-of-round canvas, which makes it
+    // show and hide with that canvas's enabled state.
     void CreateResetScoreButton()
     {
         if (finishedRoundCanvas == null) return;
@@ -155,19 +147,17 @@ public class GameManager : MonoBehaviour
         }
     }
 
-    // The clock ran out: the round is a DRAW — no winner is forced. Agents
-    // get a small negative terminal reward instead, so stalling/hiding is
-    // discouraged by incentive rather than by handing someone the win.
+    // The clock ran out: a draw, no winner forced. Agents take a small negative
+    // terminal reward instead, so stalling is discouraged by incentive rather
+    // than by handing someone the win.
     void ProcessTimeout()
     {
         if (counter != null) counter.Draw();
 
         RoundEnded?.Invoke(DrawResult);
 
-        // While training, every agent (the enemy — and the player too, once
-        // it is agent-driven) takes the timeout penalty and ends its episode,
-        // resetting in place (OnEpisodeBegin) — rearm the clock and keep the
-        // scene running, no scene reload.
+        // Training: every agent takes the penalty and resets in place, so the
+        // clock is rearmed and the scene keeps running — no reload.
         if (Academy.IsInitialized && Academy.Instance.IsCommunicatorOn)
         {
             foreach (EnemyAgent agent in FindObjectsByType<EnemyAgent>(FindObjectsSortMode.None))
@@ -178,12 +168,10 @@ public class GameManager : MonoBehaviour
             return;
         }
 
-        // Human play: a draw ends the round exactly like a win — freeze the
-        // scene on the final standoff and show the banner. The end-of-round
-        // button reloads the scene, which builds a whole new round (fresh
-        // arena, fresh spawns). No agent reset here: the reload recreates
-        // everything, and skipping it keeps the enemy from visibly
-        // teleporting behind the draw screen.
+        // Human play: a draw ends the round exactly like a win, and the
+        // end-of-round button reloads into a fresh one. No agent reset here —
+        // the reload recreates everything, and skipping it keeps the enemy
+        // from visibly teleporting behind the draw screen.
         FinishRound("Draw!");
     }
 
@@ -200,9 +188,8 @@ public class GameManager : MonoBehaviour
 
     // ------------------------------------------------------------ timer UI
 
-    // Same reasoning as CreateResetScoreButton: the scene is force-binary
-    // serialized, so the clock's HUD text is built in code — top-center of
-    // the same canvas the win counter lives on.
+    // Built in code for the same reason as the reset button; hung on the same
+    // canvas as the win counter, not the end-of-round one.
     void CreateTimerText()
     {
         if (timerText != null || roundDurationSeconds <= 0f) return;

--- a/Assets/Scripts/PerceptionMemory.cs
+++ b/Assets/Scripts/PerceptionMemory.cs
@@ -1,39 +1,27 @@
 using UnityEngine;
 
-/// <summary>
-/// The NPC's only window onto the player. Enforces the sensory contract
-/// (issue #9): the NPC never knows the player's HP, and knows the player's
-/// position only while it can actually see them — outside line of sight it
-/// works from memory (the last-seen position).
-///
-/// Every policy input (RL observations, future LLM snapshot) and every
-/// action that aims or navigates at the player must go through this
-/// component. Environment code — spawning, reward computation, the sight
-/// check itself — may still read true state; only the NPC *brain* is
-/// restricted.
-///
-/// This component is the engine adapter: the remember/freeze rules live in
-/// <see cref="PerceptionState"/>, which gets fed the sight-check result and
-/// the current time.
-/// </summary>
+// The NPC's only window onto the player (sensory contract, issue #9): it never
+// knows the player's HP, and knows their position only while it can see them —
+// out of sight it works from the last-seen position.
+//
+// Every policy input and every action that aims or navigates at the player must
+// go through here. Environment code (spawning, reward computation, the sight
+// check itself) may still read true state; only the NPC brain is restricted.
+//
+// The engine adapter half; the remember/freeze rules are in PerceptionState.
 public class PerceptionMemory : MonoBehaviour
 {
     readonly PerceptionState state = new PerceptionState();
 
-    /// <summary>True while the target passes the line-of-sight check this frame.</summary>
     public bool CurrentlyVisible => state.CurrentlyVisible;
 
-    /// <summary>
-    /// Where the target was last seen. Only meaningful when
-    /// <see cref="HasEverSeen"/> is true. While visible this tracks the live
-    /// position; the moment sight breaks it freezes.
-    /// </summary>
+    // Tracks the live position while visible, then freezes. Only meaningful
+    // once HasEverSeen is true.
     public Vector3 LastSeenPosition => state.LastSeenPosition;
 
-    /// <summary>Seconds since the target was last visible. Infinity if never seen.</summary>
+    // Infinity if never seen.
     public float TimeSinceSeen => state.TimeSinceSeen(Time.time);
 
-    /// <summary>False until the first successful sighting (and after <see cref="Forget"/>).</summary>
     public bool HasEverSeen => state.HasEverSeen;
 
     EnemyBehavior behavior;
@@ -48,12 +36,9 @@ public class PerceptionMemory : MonoBehaviour
         Refresh();
     }
 
-    /// <summary>
-    /// Re-run the sight check and update memory. Also called explicitly at
-    /// the top of <see cref="EnemyBehavior.Chase"/>/<see cref="EnemyBehavior.Attack"/>
-    /// so ML-Agents decision steps (which fire from FixedUpdate) never act on
-    /// a frame-stale snapshot.
-    /// </summary>
+    // Also called explicitly from EnemyBehavior.Chase/Attack so ML-Agents
+    // decision steps, which fire from FixedUpdate, never act on a frame-stale
+    // snapshot.
     public void Refresh()
     {
         bool visible = behavior != null && behavior.IsTargetInSight();
@@ -63,7 +48,7 @@ public class PerceptionMemory : MonoBehaviour
         state.Observe(visible, visible ? behavior.target.position : Vector3.zero, Time.time);
     }
 
-    /// <summary>Wipe the memory (episode resets — last episode's sighting must not leak).</summary>
+    // Episode resets: last episode's sighting must not leak into the next.
     public void Forget()
     {
         state.Forget();

--- a/Assets/Scripts/PerceptionState.cs
+++ b/Assets/Scripts/PerceptionState.cs
@@ -1,12 +1,9 @@
 using UnityEngine;
 
-/// <summary>
-/// The remember/freeze state machine behind <see cref="PerceptionMemory"/>,
-/// engine-free so it is unit-testable without geometry or Time: while the
-/// target is visible the last-seen position tracks it; the moment visibility
-/// ends the position freezes; <see cref="Forget"/> wipes everything for
-/// episode resets. Time is injected as a plain "now" value.
-/// </summary>
+// The remember/freeze state machine behind PerceptionMemory, engine-free so it
+// is testable without geometry or Time: the last-seen position tracks the
+// target while visible and freezes the moment visibility ends. Time is injected
+// as a plain "now" value.
 public class PerceptionState
 {
     public bool CurrentlyVisible { get; private set; }
@@ -15,10 +12,9 @@ public class PerceptionState
 
     float lastSeenTime;
 
-    /// <summary>Seconds between <paramref name="now"/> and the last sighting. Infinity if never seen.</summary>
+    // Infinity if never seen.
     public float TimeSinceSeen(float now) => HasEverSeen ? now - lastSeenTime : Mathf.Infinity;
 
-    /// <summary>Record one sight-check result.</summary>
     public void Observe(bool targetVisible, Vector3 targetPosition, float now)
     {
         CurrentlyVisible = targetVisible;
@@ -30,7 +26,7 @@ public class PerceptionState
         }
     }
 
-    /// <summary>Wipe the memory (episode resets — last episode's sighting must not leak).</summary>
+    // Episode resets: last episode's sighting must not leak into the next.
     public void Forget()
     {
         CurrentlyVisible = false;

--- a/Assets/Scripts/PlayerAgent.cs
+++ b/Assets/Scripts/PlayerAgent.cs
@@ -1,13 +1,8 @@
-/// <summary>
-/// The ML-Agents brain for the agent-driven player (issue #10). The player
-/// body reuses the whole enemy combat stack — an <see cref="EnemyBehavior"/>
-/// with <c>targetTag = "NPC"</c>, an <see cref="EnemyWeapon"/> and NavMesh
-/// locomotion — so the agent shares the enemy's observation/action/reward
-/// contract and can train against it (self-play) or evaluate it with no
-/// human input. A distinct type so the two sides are distinguishable in the
-/// Inspector and logs, and can diverge later (e.g. a different reward shape
-/// or the mode-conditioned policy) without touching the enemy.
-/// </summary>
+// The ML-Agents brain for the agent-driven player (issue #10). Deriving from
+// EnemyAgent shares the enemy's observation/action/reward contract, so one
+// policy can drive both sides for self-play. A distinct type keeps the two
+// sides apart in the Inspector and logs, and lets the player side diverge later
+// without touching the enemy.
 public class PlayerAgent : EnemyAgent
 {
 }

--- a/Assets/Scripts/RewardComputer.cs
+++ b/Assets/Scripts/RewardComputer.cs
@@ -1,10 +1,8 @@
-/// <summary>
-/// The per-decision-step reward as a pure mapping, engine-free so the whole
-/// table is unit-testable without an Academy. EnemyAgent builds one from its
-/// serialized tunables in Initialize and calls it once per OnActionReceived;
-/// event-driven terminal rewards (hit/kill/death/timeout) are plain constants
-/// and stay on the agent's Health-event handlers.
-/// </summary>
+// The per-decision-step reward as a pure mapping, engine-free so the whole
+// table is testable without an Academy. EnemyAgent builds one from its
+// serialized tunables in Initialize and calls it once per OnActionReceived;
+// terminal rewards (hit/kill/death/timeout) stay on the agent's Health-event
+// handlers.
 public class RewardComputer
 {
     public float aliveRewardPerStep = 0.001f;
@@ -12,13 +10,8 @@ public class RewardComputer
     public float tooClosePenaltyPerStep = 0.005f;
     public float tooCloseDistance = 6f;
 
-    /// <summary>
-    /// Reward for one decision step, given what the step did: the chosen
-    /// action (0=Patrol, 1=Chase, 2=Attack), whether a shot actually left the
-    /// barrel, whether the target was in sight, and the true distance to the
-    /// target (environment-side read — reward computation may use true state,
-    /// see the sensory contract notes in CLAUDE.md).
-    /// </summary>
+    // action is 0=Patrol, 1=Chase, 2=Attack. distanceToTarget is a true-state
+    // read, which reward computation is allowed (sensory contract, issue #9).
     public float StepReward(int action, bool didShoot, bool targetInSight, float distanceToTarget)
     {
         float reward = aliveRewardPerStep;

--- a/Assets/Scripts/RoundClock.cs
+++ b/Assets/Scripts/RoundClock.cs
@@ -1,33 +1,27 @@
 using UnityEngine;
 
-/// <summary>
-/// The round countdown as plain state, engine-free so it is unit-testable
-/// without play mode. GameManager owns one and feeds it Time.deltaTime; who
-/// reacts to expiry (draw + freeze in human play, penalty + re-arm during
-/// training) stays GameManager's business.
-/// </summary>
+// The round countdown as plain state, engine-free so it is testable without
+// play mode. GameManager owns one and feeds it Time.deltaTime; how to react to
+// expiry (draw + freeze in human play, penalty + re-arm during training) stays
+// GameManager's business.
 public class RoundClock
 {
-    /// <summary>Round length in seconds. Zero or negative disables the clock.</summary>
+    // Zero or negative disables the clock.
     public float Duration;
 
-    /// <summary>Seconds left. Clamped at 0 while ticking; only meaningful after <see cref="Reset"/>.</summary>
+    // Only meaningful after Reset.
     public float Remaining { get; private set; }
 
     public bool Enabled => Duration > 0f;
 
-    /// <summary>Rearm to the full duration.</summary>
     public void Reset()
     {
         Remaining = Duration;
     }
 
-    /// <summary>
-    /// Advance the clock. Returns true while the clock is expired — every
-    /// tick until someone reacts (finishes the round or calls
-    /// <see cref="Reset"/>), mirroring the caller's per-frame timeout check.
-    /// A disabled clock never ticks and never expires.
-    /// </summary>
+    // Keeps returning true every tick once expired, until someone finishes the
+    // round or re-arms — that mirrors the caller's per-frame timeout check. A
+    // disabled clock never ticks and never expires.
     public bool Tick(float deltaSeconds)
     {
         if (!Enabled) return false;

--- a/Assets/Scripts/RunRng.cs
+++ b/Assets/Scripts/RunRng.cs
@@ -1,26 +1,19 @@
 using UnityEngine;
 
-/// <summary>
-/// Process-wide, seedable RNG for everything that affects evaluation
-/// reproducibility: arena selection, spawn-point sampling and patrol/wander
-/// waypoints. Two runs launched with the same seed produce the same arena
-/// sequence and the same spawn positions, which makes evaluation runs
-/// replayable (issue #13).
-///
-/// Seed priority: <c>-runSeed &lt;int&gt;</c> on the command line, then the
-/// non-zero <c>runSeed</c> Inspector field on <see cref="ArenaManager"/>,
-/// then a time-derived random seed. Whatever wins is logged at startup so
-/// even an unseeded run can be replayed after the fact.
-///
-/// Each random domain gets its own sub-stream so a variable number of draws
-/// in one domain (e.g. wander waypoints, which depend on what the policy
-/// does) cannot shift the sequences of the others (arena choice, spawns).
-///
-/// Deliberately NOT routed through here: gameplay noise that is consumed a
-/// non-deterministic number of times per frame, like <c>EnemyWeapon</c> aim
-/// spread — feeding it from these streams would desynchronise the
-/// reproducible domains between runs.
-/// </summary>
+// Process-wide, seedable RNG for everything that affects reproducibility: two
+// runs launched with the same seed build the same arenas and spawn actors in
+// the same places (issue #13).
+//
+// Seed priority: -runSeed <int> on the command line, then a non-zero runSeed on
+// ArenaManager, then a time-derived seed. Whatever wins is logged at startup,
+// so even an unseeded run can be replayed after the fact.
+//
+// Each domain gets its own sub-stream so a variable number of draws in one
+// (wander waypoints depend on what the policy does) can't shift the others.
+//
+// Deliberately NOT routed through here: noise consumed a non-deterministic
+// number of times per frame, like EnemyWeapon aim spread — it would
+// desynchronise the reproducible streams between runs.
 public static class RunRng
 {
     public enum Stream
@@ -34,9 +27,8 @@ public static class RunRng
     const int StreamCount = 3;
 
     public static bool Initialized { get; private set; }
-    /// <summary>The effective run seed. Valid once <see cref="Initialized"/>.</summary>
     public static int Seed { get; private set; }
-    /// <summary>Where the seed came from: "command line", "inspector" or "random".</summary>
+    // "command line", "inspector" or "random".
     public static string SeedSource { get; private set; } = "uninitialized";
 
     static System.Random[] streams;
@@ -54,11 +46,9 @@ public static class RunRng
         SeedSource = "uninitialized";
     }
 
-    /// <summary>
-    /// Seed the run once. Later calls are no-ops, so the streams keep
-    /// advancing across scene reloads instead of restarting every round.
-    /// <paramref name="inspectorSeed"/> 0 means "not configured".
-    /// </summary>
+    // Later calls are no-ops, so the streams keep advancing across scene
+    // reloads instead of restarting every round. inspectorSeed 0 means "not
+    // configured".
     public static void EnsureInitialized(int inspectorSeed)
     {
         if (Initialized) return;
@@ -90,13 +80,13 @@ public static class RunRng
                   $"Replay with '{CommandLineArg} {Seed}' or ArenaManager.runSeed = {Seed}.");
     }
 
-    /// <summary>Random int in [minInclusive, maxExclusive), like UnityEngine.Random.Range.</summary>
+    // [minInclusive, maxExclusive), like UnityEngine.Random.Range.
     public static int Range(Stream stream, int minInclusive, int maxExclusive)
     {
         return Get(stream).Next(minInclusive, maxExclusive);
     }
 
-    /// <summary>Random float in [minInclusive, maxInclusive], like UnityEngine.Random.Range.</summary>
+    // [minInclusive, maxInclusive], like UnityEngine.Random.Range.
     public static float Range(Stream stream, float minInclusive, float maxInclusive)
     {
         return minInclusive + (float)Get(stream).NextDouble() * (maxInclusive - minInclusive);

--- a/Assets/Scripts/TelemetryLogger.cs
+++ b/Assets/Scripts/TelemetryLogger.cs
@@ -5,14 +5,9 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 
 // Match telemetry (issue #12): one JSON line per event under
-// persistentDataPath/Telemetry/, so every evaluation phase of the thesis
-// (training debug, headless eval, LLM A/B, human study) reads one format.
-// Events: session_start, shot, damage, death, episode_summary, session_end.
-//
-// Pure file IO + event subscriptions, so it works unchanged in -batchmode.
-// Auto-bootstraps at startup (the scene is binary serialized) and survives
-// scene reloads via DontDestroyOnLoad. Episode bookkeeping and line
-// formatting live in EpisodeLog / JsonLine; this is the Unity adapter.
+// persistentDataPath/Telemetry/, parseable without a Unity build. File IO
+// only, so it works in -batchmode. Auto-bootstraps at startup (the scene is
+// binary serialized) and survives scene reloads via DontDestroyOnLoad.
 public class TelemetryLogger : MonoBehaviour
 {
     public static TelemetryLogger Instance { get; private set; }
@@ -103,8 +98,8 @@ public class TelemetryLogger : MonoBehaviour
         catch (IOException) { } // already broken, nothing left to salvage
     }
 
-    // Append one event line. Public so future systems (NPC mode changes, LLM
-    // decisions) emit through the same bus; build fields with JsonLine.Field.
+    // Public so future systems (NPC mode changes, LLM decisions) emit through
+    // the same bus; build fields with JsonLine.Field.
     public void LogEvent(string type, params string[] jsonFields)
     {
         if (writer == null) return;

--- a/Assets/Scripts/Weapon.cs
+++ b/Assets/Scripts/Weapon.cs
@@ -21,7 +21,7 @@ public abstract class Weapon : MonoBehaviour
     protected abstract Vector3 GetForward();
 
     // Telemetry hook (issue #12): weapon, the Health hit (null on a miss),
-    // damage. Fired once per shot.
+    // damage.
     public static event System.Action<Weapon, Health, float> ShotFired;
 
     public void Shoot()

--- a/Assets/Tests/EditMode/CounterDataTests.cs
+++ b/Assets/Tests/EditMode/CounterDataTests.cs
@@ -1,11 +1,8 @@
 using NUnit.Framework;
 using UnityEngine;
 
-/// <summary>
-/// CounterData persists the win/loss/draw tally in PlayerPrefs. The fixture
-/// snapshots the real on-disk values and restores them afterwards, so running
-/// the suite never clobbers an actual score.
-/// </summary>
+// The tally lives in PlayerPrefs, so the fixture snapshots the real on-disk
+// values and restores them — running the suite must not clobber a real score.
 public class CounterDataTests
 {
     // Must match the private keys in CounterData.cs.

--- a/Assets/Tests/EditMode/DriverSelectorTests.cs
+++ b/Assets/Tests/EditMode/DriverSelectorTests.cs
@@ -1,13 +1,10 @@
 using NUnit.Framework;
 using DriverKind = CombatantRig.DriverKind;
 
-/// <summary>
-/// The player-driver priority chain (issue #10): command line beats a
-/// code-level override, which beats the Inspector default. Also the leniency
-/// the command line scan needs — the editor and player are launched with many
-/// unrelated arguments, so a malformed occurrence of the flag must be skipped
-/// rather than crash or hijack the selection.
-/// </summary>
+// The player-driver priority chain (issue #10), plus the leniency the command
+// line scan needs: the editor and player are launched with many unrelated
+// arguments, so a malformed occurrence of the flag must be skipped rather than
+// crash or hijack the selection.
 public class DriverSelectorTests
 {
     static readonly string[] NoArgs = new string[0];

--- a/Assets/Tests/EditMode/HealthTests.cs
+++ b/Assets/Tests/EditMode/HealthTests.cs
@@ -1,14 +1,12 @@
 using NUnit.Framework;
 using UnityEngine;
 
-/// <summary>
-/// Health drives the whole reward/win-loss chain (EnemyAgent subscribes to
-/// OnDamaged/OnDied, GameManager decides the round from deaths), so its event
-/// semantics are load-bearing: exact damage payloads, death fires exactly
-/// once, and ResetHealth re-arms it for the next episode.
-/// (EditMode: Start() never runs, so the GameManager lookup stays null and
-/// CheckDeath's null guard keeps death processing local to the component.)
-/// </summary>
+// Health drives the whole reward/win-loss chain — EnemyAgent subscribes to
+// OnDamaged/OnDied and GameManager decides the round from deaths — so its event
+// semantics are load-bearing.
+//
+// EditMode, so Start() never runs: the GameManager lookup stays null and
+// CheckDeath's null guard keeps death processing local to the component.
 public class HealthTests
 {
     GameObject go;

--- a/Assets/Tests/EditMode/PerceptionMemoryTests.cs
+++ b/Assets/Tests/EditMode/PerceptionMemoryTests.cs
@@ -1,13 +1,12 @@
 using NUnit.Framework;
 using UnityEngine;
 
-/// <summary>
-/// Never-seen invariants of the sensory contract: a fresh (or wiped) memory
-/// must report nothing about the player. The full sighting/freezing behavior
-/// needs real geometry and runs in PlayMode (PerceptionContractTests).
-/// (EditMode: Awake never runs, so the EnemyBehavior lookup stays null and
-/// Refresh must degrade to "not visible" rather than throw.)
-/// </summary>
+// Never-seen invariants of the sensory contract: a fresh or wiped memory must
+// report nothing about the player. The sighting/freezing behavior needs real
+// geometry and lives in PerceptionContractTests.
+//
+// EditMode, so Awake never runs: the EnemyBehavior lookup stays null and
+// Refresh must degrade to "not visible" rather than throw.
 public class PerceptionMemoryTests
 {
     GameObject go;

--- a/Assets/Tests/EditMode/PerceptionStateTests.cs
+++ b/Assets/Tests/EditMode/PerceptionStateTests.cs
@@ -1,12 +1,9 @@
 using NUnit.Framework;
 using UnityEngine;
 
-/// <summary>
-/// The remember/freeze state machine behind the sensory contract, as pure
-/// state with injected time: track while visible, freeze the moment sight
-/// breaks, wipe on Forget. (PerceptionContractTests covers the same rules
-/// end-to-end with real raycasts.)
-/// </summary>
+// The remember/freeze state machine behind the sensory contract, as pure state
+// with injected time. PerceptionContractTests covers the same rules end to end
+// with real raycasts.
 public class PerceptionStateTests
 {
     [Test]

--- a/Assets/Tests/EditMode/RewardComputerTests.cs
+++ b/Assets/Tests/EditMode/RewardComputerTests.cs
@@ -1,10 +1,7 @@
 using NUnit.Framework;
 
-/// <summary>
-/// The full per-step reward table (CLAUDE.md "Reward shape"), enumerated as
-/// pure math: alive bonus, too-close shaping penalty, wasted-shot penalty,
-/// and how they combine. Actions: 0=Patrol, 1=Chase, 2=Attack.
-/// </summary>
+// The full per-step reward table (CLAUDE.md "Reward shape") enumerated as pure
+// math, including how the penalties combine. Actions: 0=Patrol, 1=Chase, 2=Attack.
 public class RewardComputerTests
 {
     const float Tolerance = 1e-6f;

--- a/Assets/Tests/EditMode/RoundClockTests.cs
+++ b/Assets/Tests/EditMode/RoundClockTests.cs
@@ -1,10 +1,7 @@
 using NUnit.Framework;
 
-/// <summary>
-/// The round countdown as pure state: clamping, expiry semantics, re-arming,
-/// and the "duration <= 0 disables the clock" contract that GameManager and
-/// the training loop rely on.
-/// </summary>
+// The round countdown as pure state: clamping, expiry semantics, re-arming, and
+// the "duration <= 0 disables the clock" contract GameManager relies on.
 public class RoundClockTests
 {
     [Test]

--- a/Assets/Tests/EditMode/RunRngTests.cs
+++ b/Assets/Tests/EditMode/RunRngTests.cs
@@ -1,11 +1,8 @@
 using NUnit.Framework;
 
-/// <summary>
-/// Guards the reproducibility contract (CLAUDE.md "Reproducibility"): a run
-/// seed fully determines every evaluation-relevant random sequence, and each
-/// domain draws from its own sub-stream so activity in one domain can never
-/// shift the others.
-/// </summary>
+// The reproducibility contract (CLAUDE.md "Reproducibility"): a run seed fully
+// determines every random sequence that matters, and each domain draws from its
+// own sub-stream so activity in one can never shift the others.
 public class RunRngTests
 {
     [SetUp]

--- a/Assets/Tests/EditMode/StarterAssetsContractTests.cs
+++ b/Assets/Tests/EditMode/StarterAssetsContractTests.cs
@@ -4,23 +4,14 @@ using System.Linq;
 using NUnit.Framework;
 using UnityEngine;
 
-/// <summary>
-/// A canary for the one string-typed coupling in the codebase.
-///
-/// <see cref="CombatantRig"/> silences the human driver by disabling the
-/// StarterAssets first-person controller and its input component. It cannot
-/// name those types at compile time: StarterAssets has no asmdef, so it lands
-/// in Assembly-CSharp, which auto-references the URLNPC assembly — the
-/// reference cannot go back the other way (and this test assembly references
-/// URLNPC, not Assembly-CSharp, so it can't name them either). The rig
-/// therefore matches on <c>Type.Name</c>.
-///
-/// The failure mode that buys: upgrade or rename StarterAssets — or mistype
-/// the name in the rig — and the lookup quietly finds nothing, leaving human
-/// input live to fight the NavMeshAgent in agent mode. No exception, no log,
-/// just a player body pulled two ways. These asserts turn that into a red
-/// test, on both sides of the coupling.
-/// </summary>
+// A canary for the one string-typed coupling in the codebase. CombatantRig
+// silences the human driver by name because StarterAssets has no asmdef and
+// lands in Assembly-CSharp, which auto-references URLNPC — the reference can't
+// go the other way, and this test assembly can't name those types either.
+//
+// The failure mode that buys: upgrade or rename StarterAssets, or mistype the
+// name in the rig, and the lookup quietly finds nothing — no exception, no log,
+// just human input left live to fight the NavMeshAgent in agent mode.
 public class StarterAssetsContractTests
 {
     // Read from the rig itself, not a second copy: the point is to check the

--- a/Assets/Tests/PlayMode/ArenaCoverTests.cs
+++ b/Assets/Tests/PlayMode/ArenaCoverTests.cs
@@ -3,11 +3,9 @@ using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.AI;
 
-/// <summary>
-/// Contract for ArenaManager.NearestCoverPoint (issue #14): whatever it hands
-/// back sits on the NavMesh, has the threat's eye-line to it blocked and is
-/// walkable from the query origin — or it correctly reports no cover at all.
-/// </summary>
+// Contract for ArenaManager.NearestCoverPoint (issue #14): whatever it hands
+// back sits on the NavMesh, has the threat's eye-line to it blocked and is
+// walkable from the query origin — or it correctly reports no cover at all.
 public class ArenaCoverTests : PlayModeTestBase
 {
     // Must match ArenaManager's cover constants.

--- a/Assets/Tests/PlayMode/ArenaSeedingTests.cs
+++ b/Assets/Tests/PlayMode/ArenaSeedingTests.cs
@@ -4,12 +4,9 @@ using UnityEngine;
 using UnityEngine.AI;
 using UnityEngine.TestTools;
 
-/// <summary>
-/// End-to-end reproducibility (issue #13): a run seed fully determines which
-/// arena is built and where actors spawn, spawn points land on the freshly
-/// baked NavMesh at floor level, and the enemy's spawn keeps its distance
-/// from the player.
-/// </summary>
+// End-to-end reproducibility (issue #13): a run seed fully determines which
+// arena is built and where actors spawn, spawn points land on the freshly baked
+// NavMesh at floor level, and the enemy keeps its distance from the player.
 public class ArenaSeedingTests : PlayModeTestBase
 {
     ArenaManager CreateManager(int seed, int forcedIndex = -1)

--- a/Assets/Tests/PlayMode/CombatantRigTests.cs
+++ b/Assets/Tests/PlayMode/CombatantRigTests.cs
@@ -7,17 +7,13 @@ using UnityEngine.AI;
 using UnityEngine.TestTools;
 using DriverKind = CombatantRig.DriverKind;
 
-/// <summary>
-/// CombatantRig composing the agent driver onto the player body (issue #10).
-/// The scene is force-binary serialized, so this stack cannot be authored and
-/// reviewed in the editor — it only ever exists as the product of
-/// EnableAgentDriver, which makes it worth asserting piece by piece.
-///
-/// The fixture has no NavMesh: the NavMeshAgent the rig adds, and
-/// EnemyBehavior.Start's respawn, both complain about that. Those logs are
-/// expected here — the rig's composition is what is under test, not
-/// navigation.
-/// </summary>
+// CombatantRig composing the agent driver onto the player body (issue #10). The
+// scene is force-binary serialized, so this stack can never be reviewed in the
+// editor — it only exists as the product of EnableAgentDriver, which is why it
+// is worth asserting piece by piece.
+//
+// No NavMesh in this fixture, so the NavMeshAgent the rig adds and
+// EnemyBehavior.Start's respawn both complain. Those logs are expected.
 public class CombatantRigTests : PlayModeTestBase
 {
     GameObject body;
@@ -29,11 +25,8 @@ public class CombatantRigTests : PlayModeTestBase
         LogAssert.ignoreFailingMessages = false;
     }
 
-    /// <summary>
-    /// A player body with the pieces the rig expects to already be there:
-    /// the "Player" tag, Health, a CharacterController and the human weapon.
-    /// Built inactive so the driver override is in place before Awake resolves.
-    /// </summary>
+    // A player body carrying what the rig expects to already be there. Built
+    // inactive so the driver override is in place before Awake resolves.
     IEnumerator BuildBody(DriverKind driver)
     {
         // The rig reads the real command line first, so an editor launched with
@@ -67,12 +60,10 @@ public class CombatantRigTests : PlayModeTestBase
     {
         yield return BuildBody(DriverKind.Agent);
 
-        // Regression guard. The round clock is the single owner of time-based
-        // episode termination (see EnemyAgent.Initialize and CLAUDE.md); the
-        // rig used to set MaxStep to 5000 here, reinstating on the player side
-        // exactly the stale value the enemy side had just been fixed for.
-        // EnemyAgentTests covers this for the Enemy prefab, which never saw
-        // the runtime-composed player.
+        // Regression guard: the rig used to set MaxStep to 5000 here,
+        // reinstating on the player side the stale value the enemy had just
+        // been fixed for. EnemyAgentTests only covers the Enemy prefab, which
+        // never sees the runtime-composed player.
         var agent = body.GetComponent<PlayerAgent>();
         Assert.That(agent, Is.Not.Null, "the agent driver must install a PlayerAgent");
         Assert.That(agent.MaxStep, Is.Zero,

--- a/Assets/Tests/PlayMode/EnemyAgentTests.cs
+++ b/Assets/Tests/PlayMode/EnemyAgentTests.cs
@@ -6,14 +6,10 @@ using UnityEngine;
 using UnityEngine.AI;
 using UnityEngine.TestTools;
 
-/// <summary>
-/// The reward/episode plumbing of EnemyAgent against a live Academy (no
-/// trainer connected — same as pressing Play): health events map to the
-/// documented reward shape, and both terminal paths (timeout, target death)
-/// end the episode and reset state. Also a wiring smoke test for the actual
-/// Enemy prefab, whose BehaviorParameters/DecisionRequester are required for
-/// ML-Agents to drive it at all (see CLAUDE.md).
-/// </summary>
+// The reward/episode plumbing of EnemyAgent against a live Academy with no
+// trainer connected, same as pressing Play. Also a wiring smoke test for the
+// real Enemy prefab, whose BehaviorParameters/DecisionRequester are what let
+// ML-Agents drive it at all (see CLAUDE.md).
 public class EnemyAgentTests : PlayModeTestBase
 {
     GameObject player;

--- a/Assets/Tests/PlayMode/GameManagerDeathTests.cs
+++ b/Assets/Tests/PlayMode/GameManagerDeathTests.cs
@@ -3,11 +3,9 @@ using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 
-/// <summary>
-/// Win/loss accounting: GameManager.ProcessDeath maps the loser's tag to the
-/// opposite side's score and ends the round (human-play path — the tests run
-/// with no trainer connected, exactly like a player pressing Play).
-/// </summary>
+// Win/loss accounting: ProcessDeath maps the loser's tag to the opposite side's
+// score and ends the round. No trainer is connected here, so this is the
+// human-play path, exactly like pressing Play.
 public class GameManagerDeathTests : PlayModeTestBase
 {
     [UnityTest]

--- a/Assets/Tests/PlayMode/PerceptionContractTests.cs
+++ b/Assets/Tests/PlayMode/PerceptionContractTests.cs
@@ -4,15 +4,13 @@ using UnityEngine;
 using UnityEngine.AI;
 using UnityEngine.TestTools;
 
-/// <summary>
-/// The sensory contract (issue #9) against real geometry: the NPC knows the
-/// player's position only while line of sight holds; the moment sight breaks
-/// the memory freezes at the last-seen point, and episode resets wipe it.
-///
-/// The enemy is assembled with its NavMeshAgent and EnemyBehavior disabled —
-/// there is no NavMesh in this fixture and the sight check needs neither
-/// Start() spawning nor navigation, only transforms and raycasts.
-/// </summary>
+// The sensory contract (issue #9) against real geometry: the NPC knows the
+// player's position only while line of sight holds, the memory freezes at the
+// last-seen point the moment sight breaks, and episode resets wipe it.
+//
+// The enemy is assembled with its NavMeshAgent and EnemyBehavior disabled —
+// there is no NavMesh here, and the sight check needs only transforms and
+// raycasts.
 public class PerceptionContractTests : PlayModeTestBase
 {
     GameObject player;

--- a/Assets/Tests/PlayMode/PlayModeTestBase.cs
+++ b/Assets/Tests/PlayMode/PlayModeTestBase.cs
@@ -4,17 +4,13 @@ using TMPro;
 using UnityEngine;
 using UnityEngine.AI;
 
-/// <summary>
-/// Shared scaffolding for PlayMode integration tests. Guarantees per test:
-/// - No auto-spawned arena: ArenaManager's bootstrap fires on every scene
-///   load (including the test runner's init scene), so the seam suppresses it
-///   and any manager/arena that already snuck in is swept.
-/// - The real score tally survives: PlayerPrefs values are snapshotted in
-///   SetUp and restored in TearDown.
-/// - Engine state is restored: Time.timeScale (GameManager.FinishRound sets
-///   it to 0), cursor state, NavMesh data, and RunRng's static streams.
-/// Spawned objects registered via Track() are destroyed on teardown.
-/// </summary>
+// Shared scaffolding for PlayMode integration tests. Guarantees per test:
+// - No auto-spawned arena. ArenaManager's bootstrap fires on every scene load,
+//   including the test runner's own init scene, so the seam suppresses it and
+//   anything that already snuck in is swept.
+// - The real score tally survives: PlayerPrefs are snapshotted and restored.
+// - Engine state is restored: Time.timeScale (FinishRound zeroes it), cursor,
+//   NavMesh data and RunRng's static streams.
 public abstract class PlayModeTestBase
 {
     // Must match the private keys in CounterData.cs.
@@ -64,18 +60,15 @@ public abstract class PlayModeTestBase
         ArenaManager.suppressAutoBootstrap = false;
     }
 
-    /// <summary>Register a spawned object for teardown destruction.</summary>
+    // Register a spawned object for teardown destruction.
     protected GameObject Track(GameObject go)
     {
         tracked.Add(go);
         return go;
     }
 
-    /// <summary>
-    /// A minimal HUD: Canvas + TMP label wired into a Counter, enough for
-    /// GameManager.Start to find a Counter and hang its runtime timer text on
-    /// the same canvas.
-    /// </summary>
+    // Enough for GameManager.Start to find a Counter and hang its runtime timer
+    // text on the same canvas.
     protected Counter CreateCounterHud()
     {
         GameObject canvasGo = Track(new GameObject("TestHud", typeof(Canvas)));
@@ -87,11 +80,8 @@ public abstract class PlayModeTestBase
         return counter;
     }
 
-    /// <summary>
-    /// GameManager on a bare GameObject. Created inactive so the round
-    /// duration is in place before Start arms the clock; the caller must
-    /// yield a frame for Start to run.
-    /// </summary>
+    // Created inactive so the round duration is in place before Start arms the
+    // clock; the caller must yield a frame for Start to run.
     protected GameManager CreateGameManager(float roundDuration)
     {
         GameObject go = Track(new GameObject("TestGameManager"));
@@ -102,10 +92,7 @@ public abstract class PlayModeTestBase
         return gm;
     }
 
-    /// <summary>
-    /// A combatant stand-in: a cube with a collider (weapons raycast) and a
-    /// Health at the given starting HP.
-    /// </summary>
+    // A combatant stand-in: a cube with a collider (weapons raycast) and Health.
     protected Health CreateCombatant(string tag, Vector3 position, float startingHealth)
     {
         GameObject go = Track(GameObject.CreatePrimitive(PrimitiveType.Cube));
@@ -122,10 +109,8 @@ public abstract class PlayModeTestBase
         return health;
     }
 
-    /// <summary>
-    /// A firing weapon aimed along +Z. Weapon reports the shooter by root
-    /// tag, so the owner tag goes on the weapon's own GameObject.
-    /// </summary>
+    // Aimed along +Z. Weapon reports the shooter by root tag, so the owner tag
+    // goes on the weapon's own GameObject.
     protected Weapon CreateWeapon(string ownerTag, Vector3 position)
     {
         GameObject go = Track(new GameObject($"Test{ownerTag}Weapon"));
@@ -144,11 +129,8 @@ public abstract class PlayModeTestBase
         protected override Vector3 GetForward() => muzzle.forward;
     }
 
-    /// <summary>
-    /// Remove any ArenaManager (auto-bootstrapped before the first SetUp
-    /// could suppress it, or left over from a test) plus its generated
-    /// geometry and NavMesh.
-    /// </summary>
+    // Removes any ArenaManager — auto-bootstrapped before the first SetUp could
+    // suppress it, or left over from a test — plus its geometry and NavMesh.
     protected static void SweepArenas()
     {
         foreach (ArenaManager manager in Object.FindObjectsByType<ArenaManager>(FindObjectsInactive.Include, FindObjectsSortMode.None))

--- a/Assets/Tests/PlayMode/RoundTimerTests.cs
+++ b/Assets/Tests/PlayMode/RoundTimerTests.cs
@@ -3,11 +3,9 @@ using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 
-/// <summary>
-/// The round clock in GameManager: countdown, re-arming, the draw-on-timeout
-/// path (human play — no communicator in tests), and the "clock disabled"
-/// configuration. Uses sub-second rounds so the suite stays fast.
-/// </summary>
+// The round clock in GameManager: countdown, re-arming, the draw-on-timeout
+// path (human play — no communicator in tests), and the disabled-clock
+// configuration. Sub-second rounds keep the suite fast.
 public class RoundTimerTests : PlayModeTestBase
 {
     [UnityTest]

--- a/Assets/Tests/PlayMode/WeaponRangeTests.cs
+++ b/Assets/Tests/PlayMode/WeaponRangeTests.cs
@@ -3,11 +3,9 @@ using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 
-/// <summary>
-/// Hitscan weapons must have no distance cap (issue #18): line of sight is the
-/// only thing that decides whether a shot lands. Exercised through a test
-/// subclass so aim is exact — EnemyWeapon's spread would miss at these ranges.
-/// </summary>
+// Hitscan weapons have no distance cap (issue #18): line of sight is the only
+// thing deciding whether a shot lands. Exercised through a test subclass so aim
+// is exact — EnemyWeapon's spread would miss at these ranges.
 public class WeaponRangeTests : PlayModeTestBase
 {
     class TestWeapon : Weapon


### PR DESCRIPTION
Goes through every project file (`Assets/Scripts`, `Assets/Tests`, `Assets/Editor` — third-party code left alone) and cuts the comments back to what the code can't say for itself.

Every XML doc block is gone, rewritten as a short `//` note where there was something worth keeping. Same for narration of the call below it, and the research framing on the `TelemetryLogger` header. Gotchas, ordering constraints and non-obvious whys stayed.

No code changes: the diff is comments and blank lines only. Both suites pass locally.

Closes #31