### PR TITLE
Match NearestCoverPoint's LOS probe to the real actors

### DIFF
--- a/Assets/Scripts/ArenaManager.cs
+++ b/Assets/Scripts/ArenaManager.cs
@@ -35,6 +35,9 @@ public class ArenaManager : MonoBehaviour
     // Every LOS-blocking box this arena was built from, so cover queries don't
     // have to raycast-search the world.
     readonly List<Collider> coverColliders = new List<Collider>();
+    // Reused by the LOS probe in NearestCoverPoint; that query is rate-limited,
+    // so a fixed buffer avoids a per-call allocation.
+    readonly RaycastHit[] coverLosHits = new RaycastHit[16];
 
     // Half the floor size, i.e. center to the inner wall face.
     public float HalfExtentX { get; private set; }
@@ -149,14 +152,21 @@ public class ArenaManager : MonoBehaviour
 
     // ----------------------------------------------------------------- cover
 
-    const float EyeHeight = 1f;          // matches EnemyBehavior's sight-ray origin
     const float CoverStandOff = 1.2f;    // how far behind the cover face to stand
 
     // Nearest walkable point hidden from breakLosFrom and reachable from `from`.
     // False when this layout offers none — the caller must fall back to another
-    // action. The mask must be the threat's own (EnemyBehavior.SightObstacleMask),
-    // or a point comes back "hidden" behind geometry the threat sees through.
-    public bool NearestCoverPoint(Vector3 from, Vector3 breakLosFrom, LayerMask sightObstacleMask, out Vector3 coverPoint)
+    // action. Two things must match the real actors, so the caller supplies them:
+    // `sightObstacleMask` is the threat's own (EnemyBehavior.SightObstacleMask),
+    // or a point comes back "hidden" behind geometry the threat sees through; and
+    // `eyeHeight` is where the actor's sight ray really starts above the floor —
+    // the Enemy's NavMeshAgent base offset lifts it, so a 1 m constant would call
+    // a point hidden behind a 1.5 m wall that the 2 m head clears. `asker` is the
+    // agent running the query: its own colliders are ignored, or its capsule can
+    // block the LOS probe and get an exposed point accepted (the default `~0`
+    // mask sees it, and arena geometry shares its layer).
+    public bool NearestCoverPoint(Vector3 from, Vector3 breakLosFrom, LayerMask sightObstacleMask,
+        Transform asker, float eyeHeight, out Vector3 coverPoint)
     {
         coverPoint = default;
         // Snap the origin on-mesh, otherwise the path checks below all fail.
@@ -165,7 +175,7 @@ public class ArenaManager : MonoBehaviour
             from = fromHit.position;
         }
 
-        Vector3 threatEye = breakLosFrom + Vector3.up * EyeHeight;
+        Vector3 threatEye = breakLosFrom + Vector3.up * eyeHeight;
         NavMeshPath path = new NavMeshPath();
         float bestDist = float.PositiveInfinity;
         bool found = false;
@@ -193,10 +203,8 @@ public class ArenaManager : MonoBehaviour
 
             // Something has to interrupt the threat's eye-line — normally this
             // very object, so low geometry like stair steps self-rejects.
-            Vector3 candidateEye = candidate + Vector3.up * EyeHeight;
-            Vector3 toCandidate = candidateEye - threatEye;
-            if (!Physics.Raycast(threatEye, toCandidate.normalized, toCandidate.magnitude - 0.1f,
-                    sightObstacleMask, QueryTriggerInteraction.Ignore)) continue;
+            Vector3 candidateEye = candidate + Vector3.up * eyeHeight;
+            if (!EyeLineBlocked(threatEye, candidateEye, sightObstacleMask, asker)) continue;
 
             if (!NavMesh.CalculatePath(from, candidate, NavMesh.AllAreas, path)) continue;
             if (path.status != NavMeshPathStatus.PathComplete) continue;
@@ -206,6 +214,26 @@ public class ArenaManager : MonoBehaviour
             found = true;
         }
         return found;
+    }
+
+    // Is the eye-line from `eye` to `targetEye` broken by something other than
+    // the asker's own body? A plain Physics.Raycast would accept the asker's
+    // capsule as the blocker and call an exposed point covered, so walk the hits
+    // and ignore anything under `asker`.
+    bool EyeLineBlocked(Vector3 eye, Vector3 targetEye, LayerMask sightObstacleMask, Transform asker)
+    {
+        Vector3 toTarget = targetEye - eye;
+        float distance = toTarget.magnitude - 0.1f;
+        if (distance <= 0f) return false;
+
+        int count = Physics.RaycastNonAlloc(eye, toTarget.normalized, coverLosHits, distance,
+            sightObstacleMask, QueryTriggerInteraction.Ignore);
+        for (int i = 0; i < count; i++)
+        {
+            if (asker != null && coverLosHits[i].transform.IsChildOf(asker)) continue;
+            return true;
+        }
+        return false;
     }
 
     // ------------------------------------------------------------- lifecycle

--- a/Assets/Scripts/ArenaManager.cs
+++ b/Assets/Scripts/ArenaManager.cs
@@ -159,12 +159,15 @@ public class ArenaManager : MonoBehaviour
     // action. Two things must match the real actors, so the caller supplies them:
     // `sightObstacleMask` is the threat's own (EnemyBehavior.SightObstacleMask),
     // or a point comes back "hidden" behind geometry the threat sees through; and
-    // `eyeHeight` is where the actor's sight ray really starts above the floor —
-    // the Enemy's NavMeshAgent base offset lifts it, so a 1 m constant would call
-    // a point hidden behind a 1.5 m wall that the 2 m head clears. `asker` is the
-    // agent running the query: its own colliders are ignored, or its capsule can
-    // block the LOS probe and get an exposed point accepted (the default `~0`
-    // mask sees it, and arena geometry shares its layer).
+    // `eyeHeight` is the asker's own height above the floor — the head cover has
+    // to hide, so a 1 m constant would call a point hidden behind a 1.5 m wall
+    // that a 2 m head clears. Both parameters stand in for the threat too: the
+    // same eyeHeight raises the threat's eye and the asker's, so a human player's
+    // real eye level isn't modelled — the asker's is used for both, the same
+    // approximation as the mask. `asker` is the agent running the query: its own
+    // colliders are ignored, or its capsule can block the LOS probe and get an
+    // exposed point accepted (the default `~0` mask sees it, and arena geometry
+    // shares its layer).
     public bool NearestCoverPoint(Vector3 from, Vector3 breakLosFrom, LayerMask sightObstacleMask,
         Transform asker, float eyeHeight, out Vector3 coverPoint)
     {

--- a/Assets/Scripts/CombatantRig.cs
+++ b/Assets/Scripts/CombatantRig.cs
@@ -89,6 +89,9 @@ public class CombatantRig : MonoBehaviour
         if (cc != null)
         {
             nav.radius = cc.radius;
+            // Height also feeds MoveToCover's eye height, so the agent player
+            // judges cover against its real head instead of a shorter default
+            // one — leaving it unset reintroduces the #56 low-cover bug.
             nav.height = cc.height;
         }
 

--- a/Assets/Scripts/EnemyBehavior.cs
+++ b/Assets/Scripts/EnemyBehavior.cs
@@ -169,13 +169,14 @@ public class EnemyBehavior : MonoBehaviour
             // The query wants the mask of whatever blocks the *threat's* view;
             // a human player has no sight model to read, so the NPC's own
             // stands in. The same thing while both keep the default. Eye height
-            // is where this body's sight ray starts above the floor — the agent
-            // base offset lifts transform.position, plus the ray's own metre
-            // (see IsTargetInSight) — so cover is judged against the real head.
+            // is the agent's full height — the head above its grounded base that
+            // cover has to hide. Reading height, not baseOffset + 1, keeps it
+            // right whether the body is centred on a lifted transform (the Enemy
+            // prefab) or stands feet-on-mesh (CombatantRig's agent player).
             nextCoverQueryTime = Time.time + coverQueryInterval;
             hasCoverPoint = ArenaManager.Current.NearestCoverPoint(
                 transform.position, Perception.LastSeenPosition, sightObstacleMask,
-                transform, navMeshAgent.baseOffset + 1f, out coverPoint);
+                transform, navMeshAgent.height, out coverPoint);
         }
 
         if (!hasCoverPoint)

--- a/Assets/Scripts/EnemyBehavior.cs
+++ b/Assets/Scripts/EnemyBehavior.cs
@@ -168,10 +168,14 @@ public class EnemyBehavior : MonoBehaviour
         {
             // The query wants the mask of whatever blocks the *threat's* view;
             // a human player has no sight model to read, so the NPC's own
-            // stands in. The same thing while both keep the default.
+            // stands in. The same thing while both keep the default. Eye height
+            // is where this body's sight ray starts above the floor — the agent
+            // base offset lifts transform.position, plus the ray's own metre
+            // (see IsTargetInSight) — so cover is judged against the real head.
             nextCoverQueryTime = Time.time + coverQueryInterval;
             hasCoverPoint = ArenaManager.Current.NearestCoverPoint(
-                transform.position, Perception.LastSeenPosition, sightObstacleMask, out coverPoint);
+                transform.position, Perception.LastSeenPosition, sightObstacleMask,
+                transform, navMeshAgent.baseOffset + 1f, out coverPoint);
         }
 
         if (!hasCoverPoint)

--- a/Assets/Tests/PlayMode/ArenaCoverTests.cs
+++ b/Assets/Tests/PlayMode/ArenaCoverTests.cs
@@ -8,7 +8,9 @@ using UnityEngine.AI;
 // walkable from the query origin — or it correctly reports no cover at all.
 public class ArenaCoverTests : PlayModeTestBase
 {
-    // Must match ArenaManager's cover constants.
+    // Eye height of a baseOffset-0 rig: the sight ray's own metre and nothing
+    // more. The real Enemy adds its NavMeshAgent base offset on top — see
+    // EyeHeightTracksBaseOffset (issue #56).
     const float EyeHeight = 1f;
     // Stands in for the threat's own sight mask (EnemyBehavior defaults to ~0).
     const int SightMask = ~0;
@@ -36,10 +38,12 @@ public class ArenaCoverTests : PlayModeTestBase
     }
 
     // The same eye-line the implementation promises to have blocked.
-    static bool LosBlocked(Vector3 threat, Vector3 point)
+    static bool LosBlocked(Vector3 threat, Vector3 point) => LosBlockedAt(threat, point, EyeHeight);
+
+    static bool LosBlockedAt(Vector3 threat, Vector3 point, float eyeHeight)
     {
-        Vector3 eye = threat + Vector3.up * EyeHeight;
-        Vector3 toPoint = (point + Vector3.up * EyeHeight) - eye;
+        Vector3 eye = threat + Vector3.up * eyeHeight;
+        Vector3 toPoint = (point + Vector3.up * eyeHeight) - eye;
         return Physics.Raycast(eye, toPoint.normalized, toPoint.magnitude - 0.1f,
             SightMask, QueryTriggerInteraction.Ignore);
     }
@@ -63,7 +67,7 @@ public class ArenaCoverTests : PlayModeTestBase
             Vector3 threat = manager.RandomGroundPoint();
             if (Vector3.Distance(from, threat) < 4f) continue;
 
-            if (!manager.NearestCoverPoint(from, threat, SightMask, out Vector3 cover)) continue;
+            if (!manager.NearestCoverPoint(from, threat, SightMask, null, EyeHeight, out Vector3 cover)) continue;
             found++;
 
             string where = $"{manager.ActiveArenaName}: cover {cover} for from {from}, threat {threat}";
@@ -84,8 +88,8 @@ public class ArenaCoverTests : PlayModeTestBase
         Vector3 west = new Vector3(-14f, 0f, -12f);
         Vector3 east = new Vector3(14f, 0f, -12f);
 
-        Assert.That(manager.NearestCoverPoint(west, threat, SightMask, out Vector3 westCover), Is.True);
-        Assert.That(manager.NearestCoverPoint(east, threat, SightMask, out Vector3 eastCover), Is.True);
+        Assert.That(manager.NearestCoverPoint(west, threat, SightMask, null, EyeHeight, out Vector3 westCover), Is.True);
+        Assert.That(manager.NearestCoverPoint(east, threat, SightMask, null, EyeHeight, out Vector3 eastCover), Is.True);
 
         // Same threat means both queries saw the same candidates, so each
         // origin must have kept the one nearer to it — as long as the other
@@ -101,13 +105,13 @@ public class ArenaCoverTests : PlayModeTestBase
         ArenaManager manager = CreateManager(0);
         Vector3 from = new Vector3(-14f, 0f, -14f);
         Vector3 threat = Vector3.zero;
-        Assert.That(manager.NearestCoverPoint(from, threat, SightMask, out Vector3 _), Is.True,
+        Assert.That(manager.NearestCoverPoint(from, threat, SightMask, null, EyeHeight, out Vector3 _), Is.True,
             "sanity: the intact courtyard has cover");
 
         StripCoverGeometry();
         Physics.SyncTransforms();
 
-        Assert.That(manager.NearestCoverPoint(from, threat, SightMask, out Vector3 _), Is.False,
+        Assert.That(manager.NearestCoverPoint(from, threat, SightMask, null, EyeHeight, out Vector3 _), Is.False,
             "with every cover box gone the caller must be told to fall back");
     }
 
@@ -117,7 +121,7 @@ public class ArenaCoverTests : PlayModeTestBase
         ArenaManager manager = CreateManager(0);
         Vector3 crate = new Vector3(-12f, 0f, 10f); // dead centre of a corner crate stack
 
-        Assert.That(manager.NearestCoverPoint(new Vector3(0f, 0f, -14f), crate, SightMask, out Vector3 cover), Is.True,
+        Assert.That(manager.NearestCoverPoint(new Vector3(0f, 0f, -14f), crate, SightMask, null, EyeHeight, out Vector3 cover), Is.True,
             "the rest of the courtyard still offers cover");
         Assert.That(float.IsNaN(cover.x) || float.IsNaN(cover.z), Is.False, "degenerate direction leaked a NaN");
         Assert.That(LosBlocked(crate, cover), Is.True);
@@ -129,16 +133,16 @@ public class ArenaCoverTests : PlayModeTestBase
         ArenaManager manager = CreateManager(0);
         Vector3 from = new Vector3(-14f, 0f, -14f);
         Vector3 threat = Vector3.zero;
-        Assert.That(manager.NearestCoverPoint(from, threat, SightMask, out Vector3 _), Is.True,
+        Assert.That(manager.NearestCoverPoint(from, threat, SightMask, null, EyeHeight, out Vector3 _), Is.True,
             "sanity: the intact courtyard has cover");
 
         const int ghostLayer = 2; // "Ignore Raycast" — a built-in layer, always defined
         MoveCoverToLayer(ghostLayer);
         Physics.SyncTransforms();
 
-        Assert.That(manager.NearestCoverPoint(from, threat, ~(1 << ghostLayer), out Vector3 seen), Is.False,
+        Assert.That(manager.NearestCoverPoint(from, threat, ~(1 << ghostLayer), null, EyeHeight, out Vector3 seen), Is.False,
             $"{seen} counts as cover behind geometry this threat's sight ray goes straight through");
-        Assert.That(manager.NearestCoverPoint(from, threat, SightMask, out Vector3 _), Is.True,
+        Assert.That(manager.NearestCoverPoint(from, threat, SightMask, null, EyeHeight, out Vector3 _), Is.True,
             "the same boxes are cover again for a threat whose mask includes their layer");
     }
 
@@ -164,7 +168,7 @@ public class ArenaCoverTests : PlayModeTestBase
         Assert.That(NavMesh.SamplePosition(center + new Vector3(0f, 1f, -3.5f), out NavMeshHit _, 1.5f, NavMesh.AllAreas),
             Is.True, "sanity: there is walkable floor on the far side of the step");
 
-        Assert.That(manager.NearestCoverPoint(from, threat, SightMask, out Vector3 cover), Is.False,
+        Assert.That(manager.NearestCoverPoint(from, threat, SightMask, null, EyeHeight, out Vector3 cover), Is.False,
             $"a {bounds.size.y:0.00} m step is not cover, but {cover} was offered");
     }
 
@@ -183,7 +187,7 @@ public class ArenaCoverTests : PlayModeTestBase
         int coveredWhileIntact = 0;
         for (int i = 0; i < origins.Length; i++)
         {
-            if (manager.NearestCoverPoint(origins[i], threats[i], SightMask, out Vector3 _)) coveredWhileIntact++;
+            if (manager.NearestCoverPoint(origins[i], threats[i], SightMask, null, EyeHeight, out Vector3 _)) coveredWhileIntact++;
         }
         Assert.That(coveredWhileIntact, Is.GreaterThan(0), "sanity: the intact pit covers some of these pairs");
 
@@ -192,9 +196,67 @@ public class ArenaCoverTests : PlayModeTestBase
 
         for (int i = 0; i < origins.Length; i++)
         {
-            Assert.That(manager.NearestCoverPoint(origins[i], threats[i], SightMask, out Vector3 cover), Is.False,
+            Assert.That(manager.NearestCoverPoint(origins[i], threats[i], SightMask, null, EyeHeight, out Vector3 cover), Is.False,
                 $"pair #{i} (from {origins[i]}, threat {threats[i]}) was offered {cover} behind a stair step");
         }
+    }
+
+    // Issue #56, part 1: EyeHeight was a 1 m constant, but the Enemy's
+    // NavMeshAgent base offset lifts its sight ray to 2 m. A waist-high wall
+    // that hides a 1 m eye leaves a 2 m head exposed, so the eye height the
+    // caller passes must decide whether the wall counts as cover.
+    [Test]
+    public void EyeHeightTracksBaseOffset_ATallHeadClearsALowWall()
+    {
+        ArenaManager manager = CreateManager(0); // Courtyard has waist-high LowWalls
+        Transform wall = StripCoverGeometryExceptOne("LowWall");
+        Physics.SyncTransforms();
+        Bounds bounds = wall.GetComponent<Collider>().bounds;
+        Assert.That(bounds.size.y, Is.InRange(1f, 2f),
+            "sanity: the kept wall must sit between the two eye heights under test");
+
+        Vector3 center = new Vector3(bounds.center.x, 0f, bounds.center.z);
+        Vector3 threat = center + new Vector3(0f, 0f, 4f);  // toward the arena centre
+        Vector3 from = center + new Vector3(0f, 0f, -5f);   // out behind the wall
+
+        Assert.That(manager.NearestCoverPoint(from, threat, SightMask, null, 1f, out Vector3 low), Is.True,
+            "the low wall should hide a 1 m eye");
+        Assert.That(LosBlockedAt(threat, low, 1f), Is.True);
+
+        Assert.That(manager.NearestCoverPoint(from, threat, SightMask, null, 2f, out Vector3 high), Is.False,
+            $"a 1.5 m wall can't hide a 2 m head, but {high} was offered");
+    }
+
+    // Issue #56, part 2: the LOS probe accepted a candidate the moment its ray
+    // hit anything, so with the default ~0 mask the asking agent's own capsule
+    // — sharing the arena's layer and standing on the eye-line — got an exposed
+    // point called cover. Passing the asker lets the probe skip its own body.
+    [Test]
+    public void TheAskersOwnBodyDoesNotCountAsCover()
+    {
+        ArenaManager manager = CreateManager(0);
+        Transform wall = StripCoverGeometryExceptOne("LowWall");
+        Physics.SyncTransforms();
+        Bounds bounds = wall.GetComponent<Collider>().bounds;
+        Vector3 center = new Vector3(bounds.center.x, 0f, bounds.center.z);
+        Vector3 threat = center + new Vector3(0f, 0f, 4f);
+        Vector3 from = center + new Vector3(0f, 0f, -5f);
+
+        // At a 2 m eye the wall no longer hides the point: correctly no cover.
+        Assert.That(manager.NearestCoverPoint(from, threat, SightMask, null, 2f, out Vector3 _), Is.False,
+            "sanity: with the head above the wall the point is exposed");
+
+        // Drop the asker's body on the eye-line, tall enough to cross a 2 m ray.
+        GameObject body = Track(new GameObject("AskerBody"));
+        body.transform.position = new Vector3(center.x, 1f, center.z);
+        var col = body.AddComponent<BoxCollider>();
+        col.size = new Vector3(1f, 4f, 1f);
+        Physics.SyncTransforms();
+
+        Assert.That(manager.NearestCoverPoint(from, threat, SightMask, null, 2f, out Vector3 fooled), Is.True,
+            $"sanity: without an asker the body is mistaken for cover ({fooled})");
+        Assert.That(manager.NearestCoverPoint(from, threat, SightMask, body.transform, 2f, out Vector3 seen), Is.False,
+            $"the asker's own body must not count as cover, but {seen} was offered");
     }
 
     // Everything the arena builder registered as cover, moved to another layer.
@@ -231,6 +293,21 @@ public class ArenaCoverTests : PlayModeTestBase
         Assert.That(step, Is.Not.Null, "the pit should have a +Z staircase to keep a step from");
         StripCoverGeometry(step);
         return step;
+    }
+
+    // Strip cover down to a single box the builder gave this name.
+    static Transform StripCoverGeometryExceptOne(string name)
+    {
+        GameObject root = GameObject.Find("Arena (Generated)");
+        Assert.That(root, Is.Not.Null, "no generated arena to strip");
+        Transform keep = null;
+        foreach (Transform child in root.transform)
+        {
+            if (child.name == name) { keep = child; break; }
+        }
+        Assert.That(keep, Is.Not.Null, $"the layout should have a {name} to keep");
+        StripCoverGeometry(keep);
+        return keep;
     }
 
     static void StripCoverGeometry(Transform keep)

--- a/Assets/Tests/PlayMode/MovementPrimitiveTests.cs
+++ b/Assets/Tests/PlayMode/MovementPrimitiveTests.cs
@@ -57,6 +57,9 @@ public class MovementPrimitiveTests : PlayModeTestBase
         // The shipped Enemy prefab lifts the body a metre off the mesh; pass 1
         // to reproduce that when a query's origin snapping is under test.
         nav.baseOffset = baseOffset;
+        // MoveToCover judges cover against the agent's head — its height. This
+        // bare rig has no body, so pin height to the eye the LOS helper checks.
+        nav.height = EyeHeight;
         behavior = enemyGo.AddComponent<EnemyBehavior>();
         behavior.enabled = false; // skip Start's random respawn: the test picks the spot
         behavior.target = player.transform;

--- a/Assets/Tests/PlayMode/MovementPrimitiveTests.cs
+++ b/Assets/Tests/PlayMode/MovementPrimitiveTests.cs
@@ -371,7 +371,7 @@ public class MovementPrimitiveTests : PlayModeTestBase
 
         StripCoverGeometry();
         Physics.SyncTransforms();
-        Assert.That(arena.NearestCoverPoint(EnemyPos, PlayerStart, SightMask, out Vector3 _), Is.False,
+        Assert.That(arena.NearestCoverPoint(EnemyPos, PlayerStart, SightMask, null, EyeHeight, out Vector3 _), Is.False,
             "sanity: no cover left to move to");
 
         float before = FlatDistance(EnemyPos, PlayerStart);
@@ -392,7 +392,7 @@ public class MovementPrimitiveTests : PlayModeTestBase
             float distance = Vector3.Distance(from, threat);
             if (distance < 6f || distance > 15f) continue;
             if (LosBlocked(threat, from)) continue;
-            if (!manager.NearestCoverPoint(from, threat, SightMask, out Vector3 cover)) continue;
+            if (!manager.NearestCoverPoint(from, threat, SightMask, null, EyeHeight, out Vector3 cover)) continue;
             float toCover = Vector3.Distance(from, cover);
             if (toCover < 2f || toCover > 10f) continue;
             return true;


### PR DESCRIPTION
Closes #56.

`NearestCoverPoint` validated cover against something other than the agents that stand there, so it handed back exposed points.

- Eye height was a 1 m constant, but the Enemy's NavMeshAgent base offset lifts its sight ray to 2 m, so a 1.5 m wall that hid a 1 m eye left the head exposed. The caller now passes its real eye height (`baseOffset` + the ray's own metre) instead of a constant that only fit the baseOffset-0 test rigs.
- The probe called a candidate covered the moment its ray hit anything, so with the default `~0` mask the asking agent's own capsule got exposed points accepted. The asker is passed in now and its own colliders are skipped.

ArenaCoverTests covers both: a tall head clearing a low wall, and the asker's body not counting as cover. Unity suite not run locally (no editor here) — CI will.