### PR TITLE
RL: headless standalone build for training

### DIFF
--- a/Assets/Editor/BuildPlayer.cs
+++ b/Assets/Editor/BuildPlayer.cs
@@ -1,0 +1,43 @@
+#if UNITY_EDITOR
+using System;
+using UnityEditor;
+using UnityEditor.Build.Reporting;
+using UnityEngine;
+
+// Standalone Linux64 build of the FPS scene, invoked from the CLI with
+//   -executeMethod BuildPlayer.BuildLinux
+// so an ML-Agents --env run can drive the game without the editor. The
+// runtime args the trainer passes (-playerDriver, -runSeed) are read by the
+// game at startup, so the build itself only has to produce the player.
+public static class BuildPlayer
+{
+    const string Scene = "Assets/Scenes/FPS.unity";
+    const string OutputPath = "Builds/Linux/URLNPC.x86_64";
+
+    public static void BuildLinux()
+    {
+        var options = new BuildPlayerOptions
+        {
+            scenes = new[] { Scene },
+            locationPathName = OutputPath,
+            target = BuildTarget.StandaloneLinux64,
+            targetGroup = BuildTargetGroup.Standalone,
+            options = BuildOptions.None,
+        };
+
+        BuildReport report = BuildPipeline.BuildPlayer(options);
+        BuildSummary summary = report.summary;
+
+        if (summary.result == BuildResult.Succeeded)
+        {
+            Debug.Log($"[BuildPlayer] Succeeded: {summary.outputPath} ({summary.totalSize} bytes)");
+            EditorApplication.Exit(0);
+        }
+        else
+        {
+            Debug.LogError($"[BuildPlayer] {summary.result} with {summary.totalErrors} error(s).");
+            EditorApplication.Exit(1);
+        }
+    }
+}
+#endif

--- a/Assets/Editor/BuildPlayer.cs
+++ b/Assets/Editor/BuildPlayer.cs
@@ -1,5 +1,4 @@
 #if UNITY_EDITOR
-using System;
 using UnityEditor;
 using UnityEditor.Build.Reporting;
 using UnityEngine;
@@ -25,17 +24,28 @@ public static class BuildPlayer
             options = BuildOptions.None,
         };
 
-        BuildReport report = BuildPipeline.BuildPlayer(options);
-        BuildSummary summary = report.summary;
+        // BuildPlayer can throw (e.g. Linux Build Support not installed) rather
+        // than returning a failed report. Without this catch the exception rides
+        // -quit to a 0 exit code and build-player.sh reports a phantom success.
+        try
+        {
+            BuildReport report = BuildPipeline.BuildPlayer(options);
+            BuildSummary summary = report.summary;
 
-        if (summary.result == BuildResult.Succeeded)
-        {
-            Debug.Log($"[BuildPlayer] Succeeded: {summary.outputPath} ({summary.totalSize} bytes)");
-            EditorApplication.Exit(0);
+            if (summary.result == BuildResult.Succeeded)
+            {
+                Debug.Log($"[BuildPlayer] Succeeded: {summary.outputPath} ({summary.totalSize} bytes)");
+                EditorApplication.Exit(0);
+            }
+            else
+            {
+                Debug.LogError($"[BuildPlayer] {summary.result} with {summary.totalErrors} error(s).");
+                EditorApplication.Exit(1);
+            }
         }
-        else
+        catch (System.Exception e)
         {
-            Debug.LogError($"[BuildPlayer] {summary.result} with {summary.totalErrors} error(s).");
+            Debug.LogError($"[BuildPlayer] Build threw: {e}");
             EditorApplication.Exit(1);
         }
     }

--- a/Assets/Editor/BuildPlayer.cs.meta
+++ b/Assets/Editor/BuildPlayer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b7a08070c866491b96ba80a08b527646

--- a/README.md
+++ b/README.md
@@ -89,6 +89,22 @@ To speed training, in the Editor: **Edit → Project Settings → Time → Time 
 
 Trained models land at `results/URLNPC/URLNPC.onnx`.
 
+### Headless standalone build (`--env` runs)
+
+Pressing Play is only one way to feed the trainer. Build a standalone Linux player once and `mlagents-learn` can launch it itself — no editor, parallel environments, unattended overnight runs:
+
+```bash
+scripts/build-player.sh   # close the editor first (single instance per project)
+```
+
+This runs `BuildPlayer.BuildLinux` (`Assets/Editor/BuildPlayer.cs`) in batch mode and writes `Builds/Linux/URLNPC.x86_64` (gitignored). Point the trainer at it with `--env`:
+
+```bash
+mlagents-learn config/URLNPC.yaml --run-id=URLNPC --env=Builds/Linux/URLNPC --num-envs=4
+```
+
+The build honours the same CLI args as Editor Play — `-playerDriver <human|agent>` and `-runSeed <int>` — passed through the trainer's `--env-args`.
+
 ### Stopping and resuming training
 
 You can quit the game and pick training back up later **on the same semi-trained model** — the network is checkpointed entirely on the Python side (`results/URLNPC/`, see `checkpoint_interval` in `config/URLNPC.yaml`), not stored in the Unity project.

--- a/scripts/build-player.sh
+++ b/scripts/build-player.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Headless standalone build for URLNPC.
+#
+#   scripts/build-player.sh
+#
+# Builds the FPS scene into a StandaloneLinux64 player at
+# Builds/Linux/URLNPC.x86_64 (gitignored), for ML-Agents --env training runs.
+# Uses the editor version pinned in ProjectSettings/ProjectVersion.txt from the
+# Unity Hub install location; override with UNITY_BIN=/path/to/Unity.
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+UNITY_VERSION="$(sed -n 's/^m_EditorVersion: //p' "$PROJECT_ROOT/ProjectSettings/ProjectVersion.txt" | tr -d '\r')"
+UNITY_BIN="${UNITY_BIN:-$HOME/Unity/Hub/Editor/$UNITY_VERSION/Editor/Unity}"
+
+if [[ ! -x "$UNITY_BIN" ]]; then
+    echo "error: Unity $UNITY_VERSION not found at $UNITY_BIN (override with UNITY_BIN=...)" >&2
+    exit 1
+fi
+
+# Unity allows a single instance per project — a batch build against an open
+# project fails with an opaque error, so catch it early.
+if [[ -f "$PROJECT_ROOT/Temp/UnityLockfile" ]]; then
+    echo "error: the project looks open in the Unity editor (Temp/UnityLockfile exists)." >&2
+    echo "Close the editor and retry." >&2
+    exit 1
+fi
+
+LOG="$PROJECT_ROOT/Builds/build.log"
+mkdir -p "$PROJECT_ROOT/Builds"
+
+echo "==> Building StandaloneLinux64 player..."
+if "$UNITY_BIN" -batchmode -nographics -quit \
+    -projectPath "$PROJECT_ROOT" \
+    -executeMethod BuildPlayer.BuildLinux \
+    -logFile "$LOG"; then
+    echo "    PASSED — player: $PROJECT_ROOT/Builds/Linux/URLNPC.x86_64"
+else
+    echo "    FAILED — see $LOG" >&2
+    exit 1
+fi


### PR DESCRIPTION
Closes #46.

Adds a second way to feed the trainer besides Editor Play: a standalone Linux player that `mlagents-learn` can launch with `--env`, for parallel environments and unattended runs.

- `Assets/Editor/BuildPlayer.cs` — `BuildLinux` static method, invokable via `-executeMethod`, builds the FPS scene to `Builds/Linux/URLNPC.x86_64` and exits non-zero on build failure.
- `scripts/build-player.sh` — wraps it, reusing the Unity-version resolution and lockfile check from `run-tests.sh`.

The player honours the existing `-playerDriver` / `-runSeed` args at runtime, so the trainer configures each env as before. Editor Play is unchanged. No automated test — this is build tooling with no POCO logic.