### PR TITLE
docs: point training docs at scripts/train.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
   python -m venv .venv && source .venv/bin/activate
   pip install -r requirements.txt
   scripts/train.sh editor <run-id> [config]   # press Play in the editor to feed it
-  scripts/train.sh build  <run-id> [config]   # headless standalone build, self-play
+  scripts/train.sh build  <run-id> [config]   # headless standalone build, live opponent
   ```
   `config` defaults to `config/URLNPC.yaml` (slice/full/self-play configs and the full walkthrough are in `docs/rl-runbook.md`). Trained models (`.onnx` files) are saved to `results/<run-id>/`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,13 +9,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Build & Run
 
 - **Play the game:** Open the project in **Unity 6000.0 LTS**, load `Assets/Scenes/FPS.unity`, press Play.
-- **ML training:** Create a Python 3.10 venv, install `requirements.txt`, then from the repo root:
+- **ML training:** Create a Python 3.10 venv, install `requirements.txt`, then drive training through `scripts/train.sh` (wraps `mlagents-learn`) from the repo root:
   ```bash
   python -m venv .venv && source .venv/bin/activate
   pip install -r requirements.txt
-  mlagents-learn config/URLNPC.yaml --run-id=URLNPC
+  scripts/train.sh editor <run-id> [config]   # press Play in the editor to feed it
+  scripts/train.sh build  <run-id> [config]   # headless standalone build, self-play
   ```
-  Trained models (`.onnx` files) are saved to `results/URLNPC/`.
+  `config` defaults to `config/URLNPC.yaml` (slice/full/self-play configs and the full walkthrough are in `docs/rl-runbook.md`). Trained models (`.onnx` files) are saved to `results/<run-id>/`.
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -81,17 +81,22 @@ The `Assets/Prefabs/Characters/Enemy.prefab` GameObject must have these componen
 
 ### Run training
 
-From the repo root, with the venv active:
+From the repo root with the venv active, `scripts/train.sh` is the one entry point for both
+paths (it wraps `mlagents-learn`):
 
 ```bash
-mlagents-learn config/URLNPC.yaml --run-id=URLNPC --force
+scripts/train.sh editor <run-id> [config] [extra mlagents args...]   # press Play to feed it
+scripts/train.sh build  <run-id> [config] [--num-envs N] [--seed S]  # headless standalone
 ```
 
-`mlagents-learn` will print "Listening on port 5004. Start training by pressing the Play button in the Unity Editor." Open the FPS scene and press **Play**. Episodes auto-reset on death (the agent calls `EndEpisode()` and `OnEpisodeBegin` re-rolls position and health).
+`config` defaults to `config/URLNPC.yaml`; the slice/full/self-play configs and a step-by-step
+walkthrough are in [`docs/rl-runbook.md`](docs/rl-runbook.md). In `editor` mode the trainer
+prints "Listening on port 5004…" — open the FPS scene and press **Play**. Episodes auto-reset
+on death (the agent calls `EndEpisode()` and `OnEpisodeBegin` re-rolls position and health).
 
 To speed training, in the Editor: **Edit → Project Settings → Time → Time Scale** can be increased, or run multiple parallel envs by duplicating the Enemy/Player setup into separate Training Areas (recommended for longer runs).
 
-Trained models land at `results/URLNPC/URLNPC.onnx`.
+Trained models land at `results/<run-id>/URLNPC.onnx`.
 
 ### Headless standalone build (`--env` runs)
 
@@ -101,23 +106,23 @@ Pressing Play is only one way to feed the trainer. Build a standalone Linux play
 scripts/build-player.sh   # close the editor first (single instance per project)
 ```
 
-This runs `BuildPlayer.BuildLinux` (`Assets/Editor/BuildPlayer.cs`) in batch mode and writes `Builds/Linux/URLNPC.x86_64` (gitignored). Point the trainer at it with `--env`:
+This runs `BuildPlayer.BuildLinux` (`Assets/Editor/BuildPlayer.cs`) in batch mode and writes `Builds/Linux/URLNPC.x86_64` (gitignored). Point the trainer at it with `scripts/train.sh build`:
 
 ```bash
-mlagents-learn config/URLNPC.yaml --run-id=URLNPC --env=Builds/Linux/URLNPC --num-envs=4
+scripts/train.sh build <run-id> [config] --num-envs=4 --seed=12345
 ```
 
-The build honours the same CLI args as Editor Play — `-playerDriver <human|agent>` and `-runSeed <int>` — passed through the trainer's `--env-args`.
+`build` runs against the standalone player and drives the player side with the shared agent policy (`-playerDriver agent`) for self-play; `--seed` becomes the build's `-runSeed`. Both are passed through the trainer's `--env-args`.
 
 ### Stopping and resuming training
 
 You can quit the game and pick training back up later **on the same semi-trained model** — the network is checkpointed entirely on the Python side (`results/URLNPC/`, see `checkpoint_interval` in `config/URLNPC.yaml`), not stored in the Unity project.
 
 1. Stop whenever: exit Play mode in the Editor and/or `Ctrl+C` the trainer.
-2. To continue, run with **`--resume`** instead of `--force`, then press **Play** again:
+2. To continue, run with **`--resume`** instead of `--force` (both pass straight through `train.sh`), then press **Play** again:
 
    ```bash
-   mlagents-learn config/URLNPC.yaml --run-id=URLNPC --resume
+   scripts/train.sh editor <run-id> config/URLNPC.yaml --resume
    ```
 
    `--resume` reloads the network weights, optimizer state, and step count from the last checkpoint. (To instead *fork* a finished model into a brand-new run, use `--initialize-from=URLNPC` with a different `--run-id`.)

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ scripts/train.sh build <run-id> [config] --num-envs=4 --seed=12345
 
 ### Stopping and resuming training
 
-You can quit the game and pick training back up later **on the same semi-trained model** — the network is checkpointed entirely on the Python side (`results/URLNPC/`, see `checkpoint_interval` in `config/URLNPC.yaml`), not stored in the Unity project.
+You can quit the game and pick training back up later **on the same semi-trained model** — the network is checkpointed entirely on the Python side (`results/<run-id>/`, see `checkpoint_interval` in the config), not stored in the Unity project.
 
 1. Stop whenever: exit Play mode in the Editor and/or `Ctrl+C` the trainer.
 2. To continue, run with **`--resume`** instead of `--force` (both pass straight through `train.sh`), then press **Play** again:
@@ -125,7 +125,7 @@ You can quit the game and pick training back up later **on the same semi-trained
    scripts/train.sh editor <run-id> config/URLNPC.yaml --resume
    ```
 
-   `--resume` reloads the network weights, optimizer state, and step count from the last checkpoint. (To instead *fork* a finished model into a brand-new run, use `--initialize-from=URLNPC` with a different `--run-id`.)
+   `--resume` reloads the network weights, optimizer state, and step count from the last checkpoint. (To instead *fork* a finished model into a brand-new run, pass `--initialize-from=<source-run-id>` under a new `<run-id>`.)
 
 The on-screen win/loss tally also survives quitting: `CounterData` persists the score to `PlayerPrefs`, so it carries across Editor Play sessions and standalone builds. Use the **Reset Score** button on the end-of-round canvas (or call `CounterData.ResetScores()`) to clear it.
 

--- a/docs/rl-runbook.md
+++ b/docs/rl-runbook.md
@@ -68,7 +68,7 @@ fixed seed for reproducibility (`--seed` becomes `-runSeed` in the build's env-a
 *Reproducible evaluation runs*):
 
 ```bash
-scripts/train.sh build slice-01 config/URLNPC-slice.yaml --num-envs=4 --seed=12345
+scripts/train.sh build slice-02 config/URLNPC-slice.yaml --num-envs=4 --seed=12345
 ```
 
 Results land in `results/<run-id>/`; reuse a `<run-id>` only with `--resume` (continue) or

--- a/docs/rl-runbook.md
+++ b/docs/rl-runbook.md
@@ -30,23 +30,50 @@ snapshot, not live like editor Play.
 
 ## 2. Run the slice
 
-The slice is the two-mode run: `ModeDirector.enabledModes` ships as `Hunt | Retreat`, so the
-director only ever commands those two and the policy learns the Hunt/Retreat split before the
-full four-mode pool. From the repo root with the venv active:
+`scripts/train.sh` is the one entry point for both training paths; it wraps `mlagents-learn`
+so you don't assemble the `--env` / `--env-args` line by hand:
 
 ```bash
-mlagents-learn config/URLNPC.yaml --run-id=slice-01 --env=Builds/Linux/URLNPC --num-envs=4
+scripts/train.sh editor <run-id> [config] [extra mlagents args...]
+scripts/train.sh build  <run-id> [config] [--num-envs N] [--seed S] [extra...]
 ```
 
-- `--run-id` names the run; results land in `results/<run-id>/`. Reuse a name only with
-  `--resume` (continue) or `--force` (overwrite).
-- `--env` points at the standalone build; drop it and press Play to drive from the editor
-  instead.
-- Reproducible run: append `--env-args -runSeed 12345` (README → *Reproducible evaluation
-  runs*). The seed is logged and recorded as `Run/Seed` per episode.
+- **`editor`** starts the trainer and waits for you to press Play — for watching behavior and
+  quick checks.
+- **`build`** runs against the standalone player from step 1, and always drives the player
+  side with the shared agent policy (`-playerDriver agent`) so both bodies fight a live
+  opponent.
+- `config` defaults to `config/URLNPC.yaml`. `--resume` / `--force` and any other flag pass
+  straight through to `mlagents-learn`.
 
-Trained model lands at `results/<run-id>/URLNPC.onnx`; checkpoints every 50k steps
-(`checkpoint_interval`), `max_steps` 1M.
+The slice is the narrowed early run: the short `config/URLNPC-slice.yaml` (50k steps,
+`summary_freq` 2000) paired with the `ModeDirector.enabledModes` default of `Hunt | Retreat`,
+so the policy learns the Hunt/Retreat split before the full four-mode, 1M-step run. Smoke it
+in the editor first:
+
+```bash
+scripts/train.sh editor slice-01 config/URLNPC-slice.yaml
+```
+
+The three configs:
+
+| Config | Steps | Use |
+|---|---|---|
+| `config/URLNPC-slice.yaml` | 50k | slice / smoke run |
+| `config/URLNPC.yaml` | 1M | full run |
+| `config/URLNPC-selfplay.yaml` | 1M | full run plus the self-play block (see step 6) |
+
+For a longer unattended run, point `build` at the standalone player with parallel envs and a
+fixed seed for reproducibility (`--seed` becomes `-runSeed` in the build's env-args; README →
+*Reproducible evaluation runs*):
+
+```bash
+scripts/train.sh build slice-01 config/URLNPC-slice.yaml --num-envs=4 --seed=12345
+```
+
+Results land in `results/<run-id>/`; reuse a `<run-id>` only with `--resume` (continue) or
+`--force` (overwrite). Trained model at `results/<run-id>/URLNPC.onnx`; the slice checkpoints
+every 25k steps, the full run every 50k (`checkpoint_interval`).
 
 ## 3. What to look for in TensorBoard
 
@@ -99,16 +126,16 @@ before your next training run so the director resumes sampling.
 ## 6. Self-play
 
 The player body can be driven by the same policy as the enemy, so both sides train against a
-live opponent instead of a static target. `CombatantRig` swaps the player between a Human
-driver and an Agent driver:
+live opponent instead of a static target. `train.sh build` already drives the player with the
+agent policy, so any `build` run has both bodies fighting. Add the `config/URLNPC-selfplay.yaml`
+config to also turn on ML-Agents' self-play block (snapshot opponents, team swaps, ELO):
 
 ```bash
-mlagents-learn config/URLNPC.yaml --run-id=selfplay-01 --env=Builds/Linux/URLNPC \
-    --num-envs=4 --env-args -playerDriver agent
+scripts/train.sh build selfplay-01 config/URLNPC-selfplay.yaml --num-envs=4
 ```
 
 The agent driver defaults to behavior name `URLNPC` / team id 1 — same behavior name as the
 enemy, so both sides share one policy. In the editor, set **Driver = Agent** on `CombatantRig`
-(or `CombatantRig.DriverOverride` from code) instead of the CLI arg. Both bodies carry a
-`ModeDirector`, so each is independently commanded during the run. Give the agent driver a
-different behavior name to train a separate player policy against the enemy.
+(or `CombatantRig.DriverOverride` from code); `editor` runs don't pass `-playerDriver`. Both
+bodies carry a `ModeDirector`, so each is independently commanded during the run. Give the
+agent driver a different behavior name to train a separate player policy against the enemy.


### PR DESCRIPTION
Follow-up to #47, which added `scripts/train.sh` and the slice/full/self-play configs.

Updates the runbook and README to drive training through `train.sh` instead of raw `mlagents-learn`:

- slice run now uses `config/URLNPC-slice.yaml` (50k smoke) with the config trio documented as a table;
- self-play uses `config/URLNPC-selfplay.yaml`, and the fact that `build` mode always drives the player as the shared agent is spelled out;
- `--seed` → `-runSeed`, and `--resume`/`--force` pass-through, are noted.

Docs-only.