### PR TITLE
Rewards: make the too-close penalty a per-mode column

### DIFF
--- a/Assets/Scripts/EnemyAgent.cs
+++ b/Assets/Scripts/EnemyAgent.cs
@@ -22,9 +22,7 @@ public class EnemyAgent : Agent
     [SerializeField] float timeoutPenalty = 0.6f;
 
     [Header("Positioning shaping")]
-    [Tooltip("Per-step penalty while the enemy is closer to the player than tooCloseDistance. Discourages melee-rush.")]
-    // Kept token-sized: at 0.005 it out-paid Hunt's closing column and taxed the
-    // one mode whose job is to close.
+    [Tooltip("Fallback per-step penalty for being closer to the player than tooCloseDistance, used only where tooClosePenaltyByMode has no entry.")]
     [SerializeField] float tooClosePenaltyPerStep = 0.001f;
     [SerializeField] float tooCloseDistance = 6f;
 
@@ -43,6 +41,8 @@ public class EnemyAgent : Agent
     [SerializeField] float[] coverRewardPerStepByMode = { 0f, 0.005f, 0.002f, 0f };
     [Tooltip("One-off reward the first time each patch of the arena is entered in an episode.")]
     [SerializeField] float[] newAreaRewardByMode = { 0f, 0f, 0f, 0.002f };
+    [Tooltip("Penalty (positive magnitude) per step inside tooCloseDistance. Zero for Hunt, which has to be free to close. Falls back to tooClosePenaltyPerStep.")]
+    [SerializeField] float[] tooClosePenaltyByMode = { 0f, 0.004f, 0.008f, 0.002f };
     [Tooltip("Side in metres of the square patches the new-area reward counts.")]
     [SerializeField] float newAreaCellSize = 6f;
 
@@ -165,7 +165,6 @@ public class EnemyAgent : Agent
         {
             aliveRewardPerStep = aliveRewardPerStep,
             wastedShotPenalty = wastedShotPenalty,
-            tooClosePenaltyPerStep = tooClosePenaltyPerStep,
             tooCloseDistance = tooCloseDistance,
         };
         foreach (NpcMode mode in NpcModes.All)
@@ -177,6 +176,7 @@ public class EnemyAgent : Agent
                 closingPerMeter = Column(closingRewardPerMeterByMode, mode, 0f),
                 coverPerStep = Column(coverRewardPerStepByMode, mode, 0f),
                 newArea = Column(newAreaRewardByMode, mode, 0f),
+                tooClosePerStep = Column(tooClosePenaltyByMode, mode, tooClosePenaltyPerStep),
             };
         }
         progress = new EpisodeProgress { areaCellSize = newAreaCellSize };

--- a/Assets/Scripts/ModeRewardTable.cs
+++ b/Assets/Scripts/ModeRewardTable.cs
@@ -14,6 +14,9 @@ public struct ModeRewardColumn
     public float coverPerStep;
     // Once per patch of the arena first entered this episode.
     public float newArea;
+    // Positive magnitude, subtracted per step while inside tooCloseDistance.
+    // Per mode (#80): as one global row it also taxed Hunt, whose job is to close.
+    public float tooClosePerStep;
 }
 
 public class ModeRewardTable

--- a/Assets/Scripts/RewardComputer.cs
+++ b/Assets/Scripts/RewardComputer.cs
@@ -27,7 +27,6 @@ public class RewardComputer
 {
     public float aliveRewardPerStep = 0.0002f;
     public float wastedShotPenalty = 0.05f;
-    public float tooClosePenaltyPerStep = 0.001f;
     public float tooCloseDistance = 6f;
 
     public readonly ModeRewardTable modes = new ModeRewardTable();
@@ -37,9 +36,9 @@ public class RewardComputer
         ModeRewardColumn column = modes[step.mode];
 
         float reward = aliveRewardPerStep;
-        if (tooClosePenaltyPerStep > 0f && step.distanceToTarget < tooCloseDistance)
+        if (column.tooClosePerStep > 0f && step.distanceToTarget < tooCloseDistance)
         {
-            reward -= tooClosePenaltyPerStep;
+            reward -= column.tooClosePerStep;
         }
         if (step.fired && step.didShoot && !step.targetInSight)
         {

--- a/Assets/Tests/EditMode/RewardComputerTests.cs
+++ b/Assets/Tests/EditMode/RewardComputerTests.cs
@@ -9,7 +9,6 @@ public class RewardComputerTests
     // The documented per-step rows, named so the arithmetic below reads as
     // "alive bonus minus penalty" rather than as bare numbers.
     const float Alive = 0.0002f;
-    const float TooClose = 0.001f;
     const float WastedShot = 0.05f;
 
     // The documented columns (#44). EnemyAgent's serialized defaults have to
@@ -20,24 +19,24 @@ public class RewardComputerTests
         {
             aliveRewardPerStep = Alive,
             wastedShotPenalty = WastedShot,
-            tooClosePenaltyPerStep = TooClose,
             tooCloseDistance = 6f,
         };
         rewards.modes[NpcMode.Hunt] = new ModeRewardColumn
         {
-            hitTarget = 0.5f, gotHit = 0.3f, closingPerMeter = 0.01f,
+            hitTarget = 0.5f, gotHit = 0.3f, closingPerMeter = 0.01f, tooClosePerStep = 0f,
         };
         rewards.modes[NpcMode.HoldCover] = new ModeRewardColumn
         {
-            hitTarget = 0.5f, gotHit = 0.6f, coverPerStep = 0.005f,
+            hitTarget = 0.5f, gotHit = 0.6f, coverPerStep = 0.005f, tooClosePerStep = 0.004f,
         };
         rewards.modes[NpcMode.Retreat] = new ModeRewardColumn
         {
             hitTarget = 0.1f, gotHit = 0.6f, closingPerMeter = -0.01f, coverPerStep = 0.002f,
+            tooClosePerStep = 0.008f,
         };
         rewards.modes[NpcMode.Patrol] = new ModeRewardColumn
         {
-            hitTarget = 0.1f, gotHit = 0.5f, newArea = 0.002f,
+            hitTarget = 0.1f, gotHit = 0.5f, newArea = 0.002f, tooClosePerStep = 0.002f,
         };
         return rewards;
     }
@@ -55,20 +54,33 @@ public class RewardComputerTests
         Assert.That(DefaultRewards().StepReward(Step()), Is.EqualTo(Alive).Within(Tolerance));
     }
 
+    // #80: the stand-off each mode wants is the mode's own column.
     [Test]
-    public void StandingTooClose_CostsTheShapingPenalty()
+    public void StandingTooClose_CostsTheCommandedModesPenalty(
+        [Values(NpcMode.HoldCover, NpcMode.Retreat, NpcMode.Patrol)] NpcMode mode)
     {
-        StepRewardInput step = Step();
+        var rewards = DefaultRewards();
+        StepRewardInput step = Step(mode);
         step.distanceToTarget = 3f;
         step.targetInSight = true;
-        Assert.That(DefaultRewards().StepReward(step),
-            Is.EqualTo(Alive - TooClose).Within(Tolerance), "melee-rushing must not pay");
+        Assert.That(rewards.StepReward(step),
+            Is.EqualTo(Alive - rewards.modes[mode].tooClosePerStep).Within(Tolerance));
+    }
+
+    [Test]
+    public void Hunt_IsFreeToClose()
+    {
+        StepRewardInput step = Step(NpcMode.Hunt);
+        step.distanceToTarget = 1f;
+        step.targetInSight = true;
+        Assert.That(DefaultRewards().StepReward(step), Is.EqualTo(Alive).Within(Tolerance),
+            "a hunting NPC must not be taxed for doing its job");
     }
 
     [Test]
     public void TooCloseBoundary_IsExclusive()
     {
-        StepRewardInput step = Step();
+        StepRewardInput step = Step(NpcMode.Retreat);
         step.distanceToTarget = 6f;
         Assert.That(DefaultRewards().StepReward(step),
             Is.EqualTo(Alive).Within(Tolerance), "exactly at tooCloseDistance is not 'too close'");
@@ -78,8 +90,10 @@ public class RewardComputerTests
     public void DisabledTooClosePenalty_IgnoresDistance()
     {
         var rewards = DefaultRewards();
-        rewards.tooClosePenaltyPerStep = 0f;
-        StepRewardInput step = Step();
+        ModeRewardColumn retreat = rewards.modes[NpcMode.Retreat];
+        retreat.tooClosePerStep = 0f;
+        rewards.modes[NpcMode.Retreat] = retreat;
+        StepRewardInput step = Step(NpcMode.Retreat);
         step.distanceToTarget = 0.5f;
         Assert.That(rewards.StepReward(step), Is.EqualTo(Alive).Within(Tolerance));
     }
@@ -124,11 +138,12 @@ public class RewardComputerTests
     [Test]
     public void Penalties_Stack()
     {
-        StepRewardInput step = Step();
+        var rewards = DefaultRewards();
+        StepRewardInput step = Step(NpcMode.Retreat);
         step.fired = step.didShoot = true;
         step.distanceToTarget = 2f;
-        Assert.That(DefaultRewards().StepReward(step),
-            Is.EqualTo(Alive - TooClose - WastedShot).Within(Tolerance));
+        Assert.That(rewards.StepReward(step),
+            Is.EqualTo(Alive - rewards.modes[NpcMode.Retreat].tooClosePerStep - WastedShot).Within(Tolerance));
     }
 
     // The rows the commanded mode does not move: same step, every mode.
@@ -137,9 +152,8 @@ public class RewardComputerTests
     {
         StepRewardInput step = Step(mode);
         step.fired = step.didShoot = true;
-        step.distanceToTarget = 2f;
         Assert.That(DefaultRewards().StepReward(step),
-            Is.EqualTo(Alive - TooClose - WastedShot).Within(Tolerance));
+            Is.EqualTo(Alive - WastedShot).Within(Tolerance));
     }
 
     [Test]
@@ -239,5 +253,17 @@ public class RewardComputerTests
         Assert.That(rewards.modes[NpcMode.Hunt].gotHit, Is.EqualTo(0.3f).Within(Tolerance));
         Assert.That(rewards.modes[NpcMode.HoldCover].gotHit, Is.EqualTo(0.6f).Within(Tolerance),
             "being hit while the job is to stay covered has to cost more");
+    }
+
+    [Test]
+    public void TooCloseColumn_FollowsTheDocumentedTable()
+    {
+        var rewards = DefaultRewards();
+        Assert.That(rewards.modes[NpcMode.Hunt].tooClosePerStep, Is.EqualTo(0f).Within(Tolerance));
+        Assert.That(rewards.modes[NpcMode.Retreat].tooClosePerStep,
+            Is.GreaterThan(rewards.modes[NpcMode.HoldCover].tooClosePerStep),
+            "opening distance is Retreat's job, so crowding must cost it the most");
+        Assert.That(rewards.modes[NpcMode.HoldCover].tooClosePerStep,
+            Is.GreaterThan(rewards.modes[NpcMode.Patrol].tooClosePerStep));
     }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,9 +95,9 @@ Global rows — the commanded mode doesn't move them:
 - `diedPenalty` `-1.0` (ends episode)
 - `wastedShotPenalty` `-0.05` (fire branch put a bullet downrange while the target was not in sight)
 - `timeoutPenalty` `-0.6` (round clock ran out — draw, ends episode)
-- `tooClosePenaltyPerStep` `-0.001` per step inside `tooCloseDistance` (6 m)
+- `tooCloseDistance` `6 m` — the radius the per-mode `tooClosePenaltyByMode` column below applies inside (the distance itself is global; only the penalty varies)
 
-**Per-mode columns (#44):** the mode in the `ModeChannel` selects which column is live, so the one-hot the policy observes actually changes what pays. Serialized as one `float[]` row per event, indexed in `NpcModes.All` order (Hunt, HoldCover, Retreat, Patrol); a row shorter than that falls back to the global `hitTargetReward`/`gotHitPenalty` (or to 0 for the rows with no global counterpart), so an Inspector edit can't throw mid-episode. Those two scalars keep their names — the binary FPS scene may carry overrides a rename would silently drop.
+**Per-mode columns (#44):** the mode in the `ModeChannel` selects which column is live, so the one-hot the policy observes actually changes what pays. Serialized as one `float[]` row per event, indexed in `NpcModes.All` order (Hunt, HoldCover, Retreat, Patrol); a row shorter than that falls back to the global `hitTargetReward`/`gotHitPenalty`/`tooClosePenaltyPerStep` (or to 0 for the rows with no global counterpart), so an Inspector edit can't throw mid-episode. Those scalars keep their names — the binary FPS scene may carry overrides a rename would silently drop.
 
 | event | Hunt | HoldCover | Retreat | Patrol |
 |---|---|---|---|---|
@@ -106,8 +106,11 @@ Global rows — the commanded mode doesn't move them:
 | `closingRewardPerMeterByMode` | +0.01 | 0 | -0.01 | 0 |
 | `coverRewardPerStepByMode` | 0 | +0.005 | +0.002 | 0 |
 | `newAreaRewardByMode` | 0 | 0 | 0 | +0.002 |
+| `tooClosePenaltyByMode` (#80) | 0 | -0.004 | -0.008 | -0.002 |
 
-The columns are the `ModeRewardTable` POCO; `RewardComputer.StepReward` takes a `StepRewardInput` (mode, fire/sight flags, distance, closing delta, cover and new-area flags), and the agent reads the same table for the hit/got-hit `Health` events. The two positional inputs come from `EpisodeProgress`: metres closed on the target since the last step (capped, so a respawn or a NavMesh warp isn't progress) and whether this step entered a `newAreaCellSize` patch of the arena not visited yet — both reset on episode begin. The cover flag is `EnemyBehavior.IsHiddenFromTarget()`, an environment-side true-state read like `DistanceToTarget()`: it probes the *target's* eye-line to this body through the shared `EyeLine.Blocked` helper at the same eye height `MoveToCover`'s cover query uses, so the point the policy is sent to is a point the column pays for. `IsTargetInSight` can't answer it — being FOV-limited it would call "in cover" every step the NPC looked away. The probe is a raycast, so the agent only fires it for modes whose column is non-zero (`RewardComputer.RewardsCover`).
+Hunt's too-close column is 0 on purpose: as one global row the penalty taxed the one mode whose job is to close, which is part of why Hunt wouldn't engage (#79).
+
+The columns are the `ModeRewardTable` POCO; `RewardComputer.StepReward` takes a `StepRewardInput` (mode, fire/sight flags, distance, closing delta, cover and new-area flags), with `tooCloseDistance` the one positional scalar that stays global, and the agent reads the same table for the hit/got-hit `Health` events. The two positional inputs come from `EpisodeProgress`: metres closed on the target since the last step (capped, so a respawn or a NavMesh warp isn't progress) and whether this step entered a `newAreaCellSize` patch of the arena not visited yet — both reset on episode begin. The cover flag is `EnemyBehavior.IsHiddenFromTarget()`, an environment-side true-state read like `DistanceToTarget()`: it probes the *target's* eye-line to this body through the shared `EyeLine.Blocked` helper at the same eye height `MoveToCover`'s cover query uses, so the point the policy is sent to is a point the column pays for. `IsTargetInSight` can't answer it — being FOV-limited it would call "in cover" every step the NPC looked away. The probe is a raycast, so the agent only fires it for modes whose column is non-zero (`RewardComputer.RewardsCover`).
 
 ## Tests
 


### PR DESCRIPTION
Closes #80.

`tooClosePenaltyPerStep` was a single global row, so it punished being under 6 m in every mode — including Hunt, whose whole job is to close. It is now `tooClosePenaltyByMode` (Hunt 0, HoldCover 0.004, Retreat 0.008, Patrol 0.002), read through the same `Column()` fallback as the other per-mode rows; `tooCloseDistance` stays global, and the old scalar is kept only as the fallback.

EditMode coverage in `RewardComputerTests` updated for the new column: per-mode penalty, Hunt free to close, boundary, disabled column, and the documented ordering. Both suites pass locally.