### PR TITLE
Rewards: lift Retreat and Patrol off the floor in 4-mode training

### DIFF
--- a/Assets/Scripts/EnemyAgent.cs
+++ b/Assets/Scripts/EnemyAgent.cs
@@ -36,11 +36,11 @@ public class EnemyAgent : Agent
     [Tooltip("Penalty (positive magnitude) for being hit, per commanded mode. Falls back to gotHitPenalty.")]
     [SerializeField] float[] gotHitPenaltyByMode = { 0.3f, 0.6f, 0.6f, 0.5f };
     [Tooltip("Reward per metre closed on the target since the last step. Negative pays for opening distance instead.")]
-    [SerializeField] float[] closingRewardPerMeterByMode = { 0.01f, 0f, -0.01f, 0f };
+    [SerializeField] float[] closingRewardPerMeterByMode = { 0.03f, 0f, -0.03f, 0f };
     [Tooltip("Per-step reward while the target's eye-line to the enemy is broken.")]
     [SerializeField] float[] coverRewardPerStepByMode = { 0f, 0.005f, 0.002f, 0f };
     [Tooltip("One-off reward the first time each patch of the arena is entered in an episode.")]
-    [SerializeField] float[] newAreaRewardByMode = { 0f, 0f, 0f, 0.002f };
+    [SerializeField] float[] newAreaRewardByMode = { 0f, 0f, 0f, 0.01f };
     [Tooltip("Penalty (positive magnitude) per step inside tooCloseDistance. Zero for Hunt, which has to be free to close. Falls back to tooClosePenaltyPerStep.")]
     [SerializeField] float[] tooClosePenaltyByMode = { 0f, 0.004f, 0.008f, 0.002f };
     [Tooltip("Side in metres of the square patches the new-area reward counts.")]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,12 +103,14 @@ Global rows — the commanded mode doesn't move them:
 |---|---|---|---|---|
 | `hitTargetRewardByMode` | +0.5 | +0.5 | +0.1 | +0.1 |
 | `gotHitPenaltyByMode` | -0.3 | -0.6 | -0.6 | -0.5 |
-| `closingRewardPerMeterByMode` | +0.01 | 0 | -0.01 | 0 |
+| `closingRewardPerMeterByMode` (#85) | +0.03 | 0 | -0.03 | 0 |
 | `coverRewardPerStepByMode` | 0 | +0.005 | +0.002 | 0 |
-| `newAreaRewardByMode` | 0 | 0 | 0 | +0.002 |
+| `newAreaRewardByMode` (#85) | 0 | 0 | 0 | +0.01 |
 | `tooClosePenaltyByMode` (#80) | 0 | -0.004 | -0.008 | -0.002 |
 
 Hunt's too-close column is 0 on purpose: as one global row the penalty taxed the one mode whose job is to close, which is part of why Hunt wouldn't engage (#79).
+
+The closing and new-area columns are 3x and 5x their first values (#85): at the old weights the first 4-mode run left Retreat and Patrol compliance near zero (0.015 and 0.005), the positional signal losing to default aggression and to having no reason to roam. HoldCover and `killTargetReward` were held fixed as controls so the lift stays attributable to these two rows.
 
 The columns are the `ModeRewardTable` POCO; `RewardComputer.StepReward` takes a `StepRewardInput` (mode, fire/sight flags, distance, closing delta, cover and new-area flags), with `tooCloseDistance` the one positional scalar that stays global, and the agent reads the same table for the hit/got-hit `Health` events. The two positional inputs come from `EpisodeProgress`: metres closed on the target since the last step (capped, so a respawn or a NavMesh warp isn't progress) and whether this step entered a `newAreaCellSize` patch of the arena not visited yet — both reset on episode begin. The cover flag is `EnemyBehavior.IsHiddenFromTarget()`, an environment-side true-state read like `DistanceToTarget()`: it probes the *target's* eye-line to this body through the shared `EyeLine.Blocked` helper at the same eye height `MoveToCover`'s cover query uses, so the point the policy is sent to is a point the column pays for. `IsTargetInSight` can't answer it — being FOV-limited it would call "in cover" every step the NPC looked away. The probe is a raycast, so the agent only fires it for modes whose column is non-zero (`RewardComputer.RewardsCover`).
 


### PR DESCRIPTION
Closes #85.

The first 4-mode run left Retreat and Patrol compliance near zero (0.015 and 0.005): the positional columns were too weak to beat default aggression or to give Patrol a reason to roam.

- `closingRewardPerMeterByMode`: Hunt +0.01 → +0.03, Retreat -0.01 → -0.03
- `newAreaRewardByMode`: Patrol +0.002 → +0.01

HoldCover and `killTargetReward` stay put as controls. Both signals stay bounded — closing is net-signed, a cell only pays once — so nothing new is farmable.

No test changes: it's a numeric retune, and `RewardComputerTests` injects its own columns rather than reading the agent's defaults. Neither the prefab nor the binary scene overrides these rows, so the new defaults take effect. Needs one full 1M run before the 5-seed batch.
